### PR TITLE
Handle errors in Observable stream for ToStream

### DIFF
--- a/src/Zafiro/Reactive/ObservableMixin.cs
+++ b/src/Zafiro/Reactive/ObservableMixin.cs
@@ -152,7 +152,7 @@ public static class ObservableMixin
             .Buffer(bufferSize)
             .Select(buffer => Observable.FromAsync(async () => await writer.WriteAsync(buffer.ToArray())))
             .Concat()
-            .Subscribe(_ => { }, onCompleted: () => { writer.Complete(); });
+            .Subscribe(_ => { }, onCompleted: () => { writer.Complete(); }, onError: exception => writer.Complete(exception));
 
         return reader.AsStream();
     }


### PR DESCRIPTION
Previously, no error handling was provided, so the exception was unhandled and resulted in app crashes.