### PR TITLE
Fix navigation and section handling, improve namespace usage

### DIFF
--- a/src/Zafiro.UI/Icon.cs
+++ b/src/Zafiro.UI/Icon.cs
@@ -1,6 +1,6 @@
 using ReactiveUI.SourceGenerators;
 
-namespace Zafiro.Avalonia;
+namespace Zafiro.UI;
 
 public partial class Icon : ReactiveObject
 {

--- a/src/Zafiro.UI/Icon.cs
+++ b/src/Zafiro.UI/Icon.cs
@@ -1,0 +1,8 @@
+using ReactiveUI.SourceGenerators;
+
+namespace Zafiro.Avalonia;
+
+public partial class Icon : ReactiveObject
+{
+    [Reactive] private string iconId;
+}

--- a/src/Zafiro.UI/Icon.cs
+++ b/src/Zafiro.UI/Icon.cs
@@ -4,5 +4,10 @@ namespace Zafiro.UI;
 
 public partial class Icon : ReactiveObject
 {
-    [Reactive] private string iconId;
+    [Reactive] private string? iconId;
+}
+
+public partial class BigIcon : ReactiveObject
+{
+    [Reactive] private string? iconId;
 }

--- a/src/Zafiro.UI/Navigation/Sections/ContentSection.cs
+++ b/src/Zafiro.UI/Navigation/Sections/ContentSection.cs
@@ -1,16 +1,13 @@
-using System.Windows.Input;
-using CSharpFunctionalExtensions;
+using System.Reactive.Linq;
 
 namespace Zafiro.UI.Navigation.Sections;
 
-public class ContentSection<T>(string name, Func<T> getViewModel, object? icon) : Section, IContentSection
+public class ContentSection<T>(string name, IObservable<T> content, object? icon) : Section, IContentSection where T : class
 {
     public string Name { get; } = name;
 
-    Func<object?> IContentSection.GetViewModel => () => GetViewModel();
-    public Func<T> GetViewModel { get; } = getViewModel;
 
     public object? Icon { get; } = icon;
 
-    public object? Content => GetViewModel();
+    public IObservable<object> Content => content.Select(object (arg) => arg);
 }

--- a/src/Zafiro.UI/Navigation/Sections/IContentSection.cs
+++ b/src/Zafiro.UI/Navigation/Sections/IContentSection.cs
@@ -2,6 +2,5 @@ namespace Zafiro.UI.Navigation.Sections;
 
 public interface IContentSection : INamedSection
 {
-    Func<object?> GetViewModel { get; }
-    object? Content { get; }
+    IObservable<object> Content { get; }
 }

--- a/src/Zafiro.UI/Navigation/Sections/Section.cs
+++ b/src/Zafiro.UI/Navigation/Sections/Section.cs
@@ -5,15 +5,15 @@ namespace Zafiro.UI.Navigation.Sections;
 public class Section
 {
     public bool IsPrimary { get; init; } = true;
-    
-    public static IContentSection Content<T>(string name, Func<T> getViewModel, object? icon, bool isPrimary = true)
+
+    public static IContentSection Content<T>(string name, IObservable<T> getViewModel, object? icon, bool isPrimary = true) where T : class
     {
         return new ContentSection<T>(name, getViewModel, icon)
         {
             IsPrimary = isPrimary,
         };
     }
-    
+
     public static ICommandSection Command(string name, ICommand command, object? icon, bool isPrimary = true)
     {
         return new CommandSection(name, command, icon)
@@ -21,7 +21,7 @@ public class Section
             IsPrimary = isPrimary,
         };
     }
-    
+
     public static ISectionSeparator Separator(bool isPrimary = true)
     {
         return new SectionSeparator

--- a/src/Zafiro.UI/Navigation/SectionsBuilder.cs
+++ b/src/Zafiro.UI/Navigation/SectionsBuilder.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Linq;
 using System.Windows.Input;
 using Zafiro.UI.Navigation.Sections;
 
@@ -9,10 +10,10 @@ public class SectionsBuilder(IServiceProvider provider)
 
     private static ISection CreateSection<T>(string name, IServiceProvider provider, object? icon = null, bool isPrimary = true) where T : notnull
     {
-        IContentSection contentSection = Section.Content(name, () => new SectionScope(provider, typeof(T)), icon, isPrimary);
+        var contentSection = Section.Content(name, Observable.Defer(() => Observable.Return(new SectionScope(provider, typeof(T)))), icon, isPrimary);
         return contentSection;
     }
-    
+
     public SectionsBuilder Add<T>(string name, object? icon = null, bool isPrimary = true) where T : notnull
     {
         sections.Add(CreateSection<T>(name, provider, icon, isPrimary));
@@ -29,7 +30,7 @@ public class SectionsBuilder(IServiceProvider provider)
         sections.Add(Section.Separator(isPrimary));
         return this;
     }
-    
+
     public SectionsBuilder Command(string name, ICommand command, object? icon, bool isPrimary = true)
     {
         sections.Add(Section.Command(name, command, icon, isPrimary));

--- a/src/Zafiro.UI/Shell/Shell.cs
+++ b/src/Zafiro.UI/Shell/Shell.cs
@@ -10,7 +10,7 @@ public partial class Shell : ReactiveObject, IShell
     public Shell(IEnumerable<ISection> sections)
     {
         Sections = sections;
-        CurrentContent = this.WhenAnyObservable(x => x.SelectedSection.Content);
+        CurrentContent = this.WhenAnyObservable(x => x.SelectedSection!.Content);
         SelectedSection = Sections.OfType<IContentSection>().FirstOrDefault();
     }
 

--- a/src/Zafiro.UI/Shell/Shell.cs
+++ b/src/Zafiro.UI/Shell/Shell.cs
@@ -1,5 +1,4 @@
-﻿using System.Reactive.Linq;
-using ReactiveUI.SourceGenerators;
+﻿using ReactiveUI.SourceGenerators;
 using Zafiro.UI.Navigation.Sections;
 
 namespace Zafiro.UI.Shell;
@@ -11,14 +10,13 @@ public partial class Shell : ReactiveObject, IShell
     public Shell(IEnumerable<ISection> sections)
     {
         Sections = sections;
-        CurrentContent = this.WhenAnyValue(x => x.SelectedSection)
-            .WhereNotNull()
-            .Select(section => section.GetViewModel());
+        CurrentContent = this.WhenAnyObservable(x => x.SelectedSection.Content);
         SelectedSection = Sections.OfType<IContentSection>().FirstOrDefault();
     }
 
-    public IEnumerable<ISection> Sections { get; }
     public IObservable<object?> CurrentContent { get; }
+
+    public IEnumerable<ISection> Sections { get; }
 
     public void GoToSection(string sectionName)
     {

--- a/src/Zafiro.UI/Shell/Utils/Extensions.cs
+++ b/src/Zafiro.UI/Shell/Utils/Extensions.cs
@@ -1,0 +1,13 @@
+using System.Reflection;
+
+namespace Zafiro.UI.Shell.Utils;
+
+public static class Extensions
+{
+    public static bool IsSection(this Type t)
+    {
+        return t is { IsClass: true, IsAbstract: false } &&
+               t.Name.EndsWith("ViewModel") &&
+               t.GetCustomAttribute<SectionAttribute>() != null;
+    }
+}

--- a/src/Zafiro.UI/Shell/Utils/NavigationExtensions.cs
+++ b/src/Zafiro.UI/Shell/Utils/NavigationExtensions.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Zafiro.Avalonia;
+using Zafiro.UI.Navigation;
+
+namespace Zafiro.UI.Shell.Utils;
+
+public static class NavigationExtensions
+{
+    public static IServiceCollection AddAllSections(this IServiceCollection services, Assembly assembly)
+    {
+        services.RegisterSections(builder =>
+        {
+            var viewModelTypes = assembly.GetTypes().Where(Extensions.IsSection);
+
+            foreach (var viewModelType in viewModelTypes)
+            {
+                string sectionName = viewModelType.Name.Replace("ViewModel", "");
+                string formattedName = string.Concat(sectionName.Select(x => char.IsUpper(x) ? " " + x : x.ToString())).TrimStart(' ');
+                var method = typeof(SectionsBuilder).GetMethod("Add")?.MakeGenericMethod(viewModelType);
+                var iconId = viewModelType.GetCustomAttribute<SectionAttribute>()!.Id;
+                method?.Invoke(builder, new object[] { formattedName, new Icon { IconId = iconId }, true });
+            }
+        });
+
+        return services;
+    }
+}

--- a/src/Zafiro.UI/Shell/Utils/NavigationExtensions.cs
+++ b/src/Zafiro.UI/Shell/Utils/NavigationExtensions.cs
@@ -10,15 +10,19 @@ public static class NavigationExtensions
     {
         services.RegisterSections(builder =>
         {
-            var viewModelTypes = assembly.GetTypes().Where(Extensions.IsSection);
+            var sections = from sectionType in assembly.GetTypes().Where(Extensions.IsSection)
+                let sectionAttribute = sectionType.GetCustomAttribute<SectionAttribute>()
+                select new { sectionType = sectionType, sectionAttribute };
 
-            foreach (var viewModelType in viewModelTypes)
+            foreach (var viewModelType in sections.OrderBy(arg => arg.sectionAttribute.SortIndex))
             {
-                string sectionName = viewModelType.Name.Replace("ViewModel", "");
+                var type = viewModelType.sectionType;
+                var icon = viewModelType.sectionAttribute.Icon;
+
+                string sectionName = type.Name.Replace("ViewModel", "");
                 string formattedName = string.Concat(sectionName.Select(x => char.IsUpper(x) ? " " + x : x.ToString())).TrimStart(' ');
-                var method = typeof(SectionsBuilder).GetMethod("Add")?.MakeGenericMethod(viewModelType);
-                var iconId = viewModelType.GetCustomAttribute<SectionAttribute>()!.Id;
-                method?.Invoke(builder, new object[] { formattedName, new Icon { IconId = iconId }, true });
+                var method = typeof(SectionsBuilder).GetMethod("Add")?.MakeGenericMethod(type);
+                method?.Invoke(builder, new object[] { formattedName, new Icon { IconId = icon ?? "fa-window-maximize" }, true });
             }
         });
 

--- a/src/Zafiro.UI/Shell/Utils/NavigationExtensions.cs
+++ b/src/Zafiro.UI/Shell/Utils/NavigationExtensions.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
-using Zafiro.Avalonia;
 using Zafiro.UI.Navigation;
 
 namespace Zafiro.UI.Shell.Utils;

--- a/src/Zafiro.UI/Shell/Utils/SectionAttribute.cs
+++ b/src/Zafiro.UI/Shell/Utils/SectionAttribute.cs
@@ -1,0 +1,7 @@
+namespace Zafiro.UI.Shell.Utils;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class SectionAttribute(string id) : Attribute
+{
+    public string Id { get; } = id;
+}

--- a/src/Zafiro.UI/Shell/Utils/SectionAttribute.cs
+++ b/src/Zafiro.UI/Shell/Utils/SectionAttribute.cs
@@ -1,7 +1,8 @@
 namespace Zafiro.UI.Shell.Utils;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class SectionAttribute(string id) : Attribute
+public class SectionAttribute(string? icon = null, int sortIndex = 0) : Attribute
 {
-    public string Id { get; } = id;
+    public string? Icon { get; } = icon;
+    public int SortIndex { get; } = sortIndex;
 }

--- a/src/Zafiro.UI/Shell/Utils/ServiceCollectionExtensions.cs
+++ b/src/Zafiro.UI/Shell/Utils/ServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Zafiro.UI.Shell.Utils;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection RegisterAllSections(this IServiceCollection services, Assembly assembly)
+    {
+        var viewModelTypes = assembly.GetTypes().Where(Extensions.IsSection);
+
+        foreach (var viewModelType in viewModelTypes)
+        {
+            services.AddScoped(viewModelType);
+        }
+
+        return services;
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces the following changes:
- Fixes a nullability issue with the `SelectedSection`'s `Content` property using the null-forgiveness operator, ensuring safe and clean null handling.
- Adds a new `BigIcon` class and makes the `iconId` property in the `Icon` class nullable.
- Adds a sort index to `SectionAttribute` and adjusts ViewModel registrations to ensure correct sorting.
- Updates namespaces from `Zafiro.Avalonia` to `Zafiro.UI` for consistency and clarity.
- Adds utilities to improve section and navigation functionality, focusing on service registration and UI components.
- Refactors navigation and section workflows to utilize reactive content handling, improving structural organization and streamlining the codebase.