### PR TITLE
Replace Nuke with dotnetdeployer

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,9 +9,14 @@ steps:
 - pwsh: dotnet tool install --global DotnetPackaging.DeployerTool
   displayName: Install DotnetPackaging.DeployerTool
 
-- pwsh: |
-    $args = if ($env:BUILD_SOURCEBRANCH -ne 'refs/heads/master') { '--no-push' } else { '' }
-    dotnetdeployer nuget --api-key $env:NUGET_API_KEY $args
+- pwsh: dotnetdeployer nuget --api-key $env:NUGET_API_KEY
   displayName: Publish NuGet packages
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+  env:
+    NUGET_API_KEY: $(NuGetApiKey)
+
+- pwsh: dotnetdeployer nuget --api-key $env:NUGET_API_KEY --no-push
+  displayName: Publish NuGet packages (dry run)
+  condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
   env:
     NUGET_API_KEY: $(NuGetApiKey)


### PR DESCRIPTION
## Summary
- remove Nuke build invocation from the pipeline
- install and run `dotnetdeployer` in Azure Pipelines

## Testing
- `dotnet test` *(fails: NETSDK1045 the current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6887e67367b8832f92b17d6370e2e242