### PR TITLE
Support next-command with previous result

### DIFF
--- a/src/Zafiro.UI/Wizards/Slim/Builder/StepDefinition.cs
+++ b/src/Zafiro.UI/Wizards/Slim/Builder/StepDefinition.cs
@@ -5,14 +5,17 @@ namespace Zafiro.UI.Wizards.Slim.Builder;
 
 public class StepDefinition<TPage, TResult>(
     Func<object?, TPage> pageFactory,
-    Func<TPage, IEnhancedCommand<Result<TResult>>>? nextCommandFactory,
+    Func<TPage, object?, IEnhancedCommand<Result<TResult>>>? nextCommandFactory,
     string title)
     : IStepDefinition
 {
+    private object? previousResult;
+
     public string Title { get; } = title;
 
     public object CreatePage(object? previousResult)
     {
+        this.previousResult = previousResult;
         return pageFactory(previousResult);
     }
 
@@ -22,7 +25,7 @@ public class StepDefinition<TPage, TResult>(
             return null;
 
         var typedPage = (TPage)page;
-        var typedCommand = nextCommandFactory(typedPage);
+        var typedCommand = nextCommandFactory(typedPage, previousResult);
         return new CommandAdapter<Result<TResult>, Result<object>>(typedCommand, result => result.Map(x => (object)x));
     }
 }


### PR DESCRIPTION
## Summary
- store the previous step result in `StepDefinition`
- adapt existing `Then` and `StartWith` overloads
- add new `Then` overload that provides previous result to the next command

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_688ca198fdd0832fbdec8c1c109ad9f4