### PR TITLE
Enable StepBuilder access to previous result

### DIFF
--- a/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilder.cs
+++ b/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilder.cs
@@ -15,4 +15,11 @@ public class StepBuilder<TPage>(IEnumerable<IStepDefinition> previousSteps, Func
         var steps = previousSteps.Append(step);
         return new WizardBuilder<TResult>(steps);
     }
+
+    public WizardBuilder<TResult> ProceedWith<TResult>(Func<TPage, object?, IEnhancedCommand<Result<TResult>>> nextCommand)
+    {
+        var step = new StepDefinition<TPage, TResult>(pageFactory, nextCommand, title);
+        var steps = previousSteps.Append(step);
+        return new WizardBuilder<TResult>(steps);
+    }
 }

--- a/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilderExtensions.cs
+++ b/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilderExtensions.cs
@@ -10,5 +10,10 @@ public static class StepBuilderExtensions
     {
         return builder.ProceedWith(page => EnhancedCommand.Create(() => nextAction(page), page.IsValid, text));
     }
+
+    public static WizardBuilder<TResult> ProceedWithResultWhenValid<TPage, TResult>(this StepBuilder<TPage> builder, Func<TPage, object?, Result<TResult>> nextAction, string? text = null) where TPage : IValidatable
+    {
+        return builder.ProceedWith((page, prev) => EnhancedCommand.Create(() => nextAction(page, prev), page.IsValid, text));
+    }
 }
 


### PR DESCRIPTION
## Summary
- support next commands that take previous step result
- allow `ProceedWithResultWhenValid` to access previous result

## Testing
- `dotnet test` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_688cea3d1f5c832f985b46354a853521