### PR TITLE
Add overloads for step builder

### DIFF
--- a/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilder.cs
+++ b/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilder.cs
@@ -15,4 +15,11 @@ public class StepBuilder<TPage>(IEnumerable<IStepDefinition> previousSteps, Func
         var steps = previousSteps.Append(step);
         return new WizardBuilder<TResult>(steps);
     }
+
+    public WizardBuilder<TResult> ProceedWith<TPreviousResult, TResult>(Func<TPage, TPreviousResult, IEnhancedCommand<Result<TResult>>> nextCommand)
+    {
+        var step = new StepDefinition<TPage, TResult>(pageFactory, (page, prev) => nextCommand(page, (TPreviousResult)prev!), title);
+        var steps = previousSteps.Append(step);
+        return new WizardBuilder<TResult>(steps);
+    }
 }

--- a/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilderExtensions.cs
+++ b/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilderExtensions.cs
@@ -10,5 +10,10 @@ public static class StepBuilderExtensions
     {
         return builder.ProceedWith(page => EnhancedCommand.Create(() => nextAction(page), page.IsValid, text));
     }
+
+    public static WizardBuilder<TResult> ProceedWithResultWhenValid<TPage, TPreviousResult, TResult>(this StepBuilder<TPage> builder, Func<TPage, TPreviousResult, Result<TResult>> nextAction, string? text = null) where TPage : IValidatable
+    {
+        return builder.ProceedWith<TPreviousResult, TResult>((page, prev) => EnhancedCommand.Create(() => nextAction(page, prev), page.IsValid, text));
+    }
 }
 


### PR DESCRIPTION
## Summary
- add a ProceedWith overload in StepBuilder that gives access to the previous result
- add matching ProceedWithResultWhenValid overload

## Testing
- `dotnet test --no-build` *(fails: System.TypeLoadException in FluentAssertions)*

------
https://chatgpt.com/codex/tasks/task_e_688cea3d1f5c832f985b46354a853521