### PR TITLE
Improve SlimWizard generics

### DIFF
--- a/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilder.cs
+++ b/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilder.cs
@@ -3,18 +3,18 @@ using Zafiro.UI.Commands;
 
 namespace Zafiro.UI.Wizards.Slim.Builder;
 
-public class StepBuilder<TPage>(IEnumerable<IStepDefinition> previousSteps, Func<object?, TPage> pageFactory, string title)
+public class StepBuilder<TPrevious, TPage>(IEnumerable<IStepDefinition> previousSteps, Func<TPrevious, TPage> pageFactory, string title)
 {
     public WizardBuilder<TResult> ProceedWith<TResult>(Func<TPage, IEnhancedCommand<Result<TResult>>> nextCommand)
     {
-        var step = new StepDefinition<TPage, TResult>(pageFactory, (page, _) => nextCommand(page), title);
+        var step = new StepDefinition<TPrevious, TPage, TResult>(pageFactory, (page, _) => nextCommand(page), title);
         var steps = previousSteps.Append(step);
         return new WizardBuilder<TResult>(steps);
     }
 
-    public WizardBuilder<TResult> ProceedWith<TPreviousResult, TResult>(Func<TPage, TPreviousResult, IEnhancedCommand<Result<TResult>>> nextCommand)
+    public WizardBuilder<TResult> ProceedWith<TResult>(Func<TPage, TPrevious, IEnhancedCommand<Result<TResult>>> nextCommand)
     {
-        var step = new StepDefinition<TPage, TResult>(pageFactory, (page, prev) => nextCommand(page, (TPreviousResult)prev!), title);
+        var step = new StepDefinition<TPrevious, TPage, TResult>(pageFactory, nextCommand, title);
         var steps = previousSteps.Append(step);
         return new WizardBuilder<TResult>(steps);
     }

--- a/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilderExtensions.cs
+++ b/src/Zafiro.UI/Wizards/Slim/Builder/StepBuilderExtensions.cs
@@ -6,14 +6,14 @@ namespace Zafiro.UI.Wizards.Slim.Builder;
 
 public static class StepBuilderExtensions
 {
-    public static WizardBuilder<TResult> ProceedWithResultWhenValid<TPage, TResult>(this StepBuilder<TPage> builder, Func<TPage, Result<TResult>> nextAction, string? text = null) where TPage : IValidatable
+    public static WizardBuilder<TResult> ProceedWithResultWhenValid<TPrevious, TPage, TResult>(this StepBuilder<TPrevious, TPage> builder, Func<TPage, Result<TResult>> nextAction, string? text = null) where TPage : IValidatable
     {
         return builder.ProceedWith(page => EnhancedCommand.Create(() => nextAction(page), page.IsValid, text));
     }
 
-    public static WizardBuilder<TResult> ProceedWithResultWhenValid<TPage, TPreviousResult, TResult>(this StepBuilder<TPage> builder, Func<TPage, TPreviousResult, Result<TResult>> nextAction, string? text = null) where TPage : IValidatable
+    public static WizardBuilder<TResult> ProceedWithResultWhenValid<TPrevious, TPage, TResult>(this StepBuilder<TPrevious, TPage> builder, Func<TPage, TPrevious, Result<TResult>> nextAction, string? text = null) where TPage : IValidatable
     {
-        return builder.ProceedWith<TPreviousResult, TResult>((page, prev) => EnhancedCommand.Create(() => nextAction(page, prev), page.IsValid, text));
+        return builder.ProceedWith((page, prev) => EnhancedCommand.Create(() => nextAction(page, prev), page.IsValid, text));
     }
 }
 

--- a/src/Zafiro.UI/Wizards/Slim/Builder/StepDefinition.cs
+++ b/src/Zafiro.UI/Wizards/Slim/Builder/StepDefinition.cs
@@ -3,20 +3,20 @@ using Zafiro.UI.Commands;
 
 namespace Zafiro.UI.Wizards.Slim.Builder;
 
-public class StepDefinition<TPage, TResult>(
-    Func<object?, TPage> pageFactory,
-    Func<TPage, object?, IEnhancedCommand<Result<TResult>>>? nextCommandFactory,
+public class StepDefinition<TPrevious, TPage, TResult>(
+    Func<TPrevious, TPage> pageFactory,
+    Func<TPage, TPrevious, IEnhancedCommand<Result<TResult>>>? nextCommandFactory,
     string title)
     : IStepDefinition
 {
-    private object? previousResult;
+    private TPrevious previousResult = default!;
 
     public string Title { get; } = title;
 
     public object CreatePage(object? previousResult)
     {
-        this.previousResult = previousResult;
-        return pageFactory(previousResult);
+        this.previousResult = previousResult is null ? default! : (TPrevious)previousResult;
+        return pageFactory(this.previousResult);
     }
 
     public IEnhancedCommand<Result<object>>? GetNextCommand(object page)


### PR DESCRIPTION
## Summary
- carry the previous step result type in the Slim wizard builder
- update helpers to infer previous result types automatically

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_688d41824840832faa9655a53e64146a