### PR TITLE
Use factories for navigation navigation stack

### DIFF
--- a/test/Zafiro.Tests/UI/NavigatorBookmarkTests.cs
+++ b/test/Zafiro.Tests/UI/NavigatorBookmarkTests.cs
@@ -24,7 +24,7 @@ public class NavigatorBookmarkTests
         services.AddTransient<Page>();
         services.AddTransient<AnotherPage>();
         var provider = services.BuildServiceProvider();
-        var navigator = new Navigator(provider, Maybe<ILogger>.None);
+        var navigator = new Navigator(provider, Maybe<ILogger>.None, null);
 
         await navigator.Go(typeof(Page));
         var bookmark = navigator.CreateBookmark();
@@ -46,7 +46,7 @@ public class NavigatorBookmarkTests
         services.AddTransient<Page>();
         services.AddTransient<AnotherPage>();
         var provider = services.BuildServiceProvider();
-        var navigator = new Navigator(provider, Maybe<ILogger>.None);
+        var navigator = new Navigator(provider, Maybe<ILogger>.None, null);
 
         await navigator.Go(typeof(Page));
         navigator.CreateBookmark("wizard");

--- a/test/Zafiro.Tests/UI/NavigatorFactoryTests.cs
+++ b/test/Zafiro.Tests/UI/NavigatorFactoryTests.cs
@@ -1,0 +1,46 @@
+using System.Reactive.Linq;
+using CSharpFunctionalExtensions;
+using Microsoft.Extensions.DependencyInjection;
+using Zafiro.UI.Navigation;
+using Serilog;
+using System.Threading.Tasks;
+
+namespace Zafiro.Tests.UI;
+
+public class NavigatorFactoryTests
+{
+    private class Page
+    {
+        public int Id { get; }
+        public Page(int id) => Id = id;
+    }
+
+    private class AnotherPage
+    {
+    }
+
+    [Fact]
+    public async Task GoBack_uses_factory_to_create_new_instance()
+    {
+        var services = new ServiceCollection();
+        var provider = services.BuildServiceProvider();
+        var navigator = new Navigator(provider, Maybe<ILogger>.None, null);
+
+        var counter = 0;
+        Page? first = null;
+        await navigator.Go(() =>
+        {
+            var page = new Page(++counter);
+            first ??= page;
+            return page;
+        });
+
+        await navigator.Go(() => new AnotherPage());
+        await navigator.GoBack();
+
+        var current = await navigator.Content.FirstAsync();
+        var second = Assert.IsType<Page>(current);
+        Assert.NotSame(first, second);
+        Assert.Equal(2, counter);
+    }
+}


### PR DESCRIPTION
## Summary
- reconstruct navigation from factories instead of cached instances
- adjust bookmark navigation to recreate views
- test navigator recreates pages when going back

## Testing
- `dotnet test` *(fails: Could not load type 'FluentAssertions.Execution.Execute')*
- `dotnet test test/Zafiro.Tests/Zafiro.Tests.csproj` *(fails: Could not load type 'FluentAssertions.Execution.Execute')*

------
https://chatgpt.com/codex/tasks/task_e_6895d64a1010832fae07ed2334d80244