### PR TITLE
Normalize formatting: whitespace-only changes across core files

### DIFF
--- a/src/Zafiro.DivineBytes/ByteSource.cs
+++ b/src/Zafiro.DivineBytes/ByteSource.cs
@@ -85,7 +85,7 @@ public class ByteSource(IObservable<byte[]> bytes) : IByteSource
 
         return new ByteSource(str.ToByteStream(encoding, bufferSize));
     }
-    
+
     public static IByteSource FromString(
         string str)
     {

--- a/src/Zafiro.DivineBytes/ByteSourcePropertiesMixin.cs
+++ b/src/Zafiro.DivineBytes/ByteSourcePropertiesMixin.cs
@@ -17,7 +17,7 @@ public static class ByteSourcePropertiesMixin
     {
         return data.ToEnumerable().Flatten().ToArray();
     }
-    
+
     public static IObservable<long> GetSize(this IObservable<byte[]> data)
     {
         return data.Sum(bytes => (long)bytes.Length);
@@ -34,7 +34,7 @@ public static class ByteSourcePropertiesMixin
                 })
             .Select(crc => crc.GetCurrentHashAsUInt32());
     }
-    
+
     public static IObservable<byte[]> Sha256(this IObservable<byte[]> data)
     {
         return data.Aggregate(
@@ -53,12 +53,12 @@ public static class ByteSourcePropertiesMixin
     {
         return byteSource.Bytes.GetSize();
     }
-    
+
     public static byte[] Array(this IByteSource byteSource)
     {
         return byteSource.Bytes.Array();
     }
-    
+
     public static IObservable<byte[]> Sha256(this IByteSource byteSource)
     {
         return byteSource.Bytes.Sha256();

--- a/src/Zafiro.DivineBytes/ByteSourceUriExtensions.cs
+++ b/src/Zafiro.DivineBytes/ByteSourceUriExtensions.cs
@@ -17,8 +17,8 @@ public static class ByteSourceUriExtensions
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A Result with the ByteSource if the operation is successful</returns>
     public static async Task<Result<IByteSource>> ToByteSourceAsync(
-        this Uri uri, 
-        IUriContentProvider contentProvider, 
+        this Uri uri,
+        IUriContentProvider contentProvider,
         CancellationToken cancellationToken = default)
     {
         return await contentProvider.GetByteSourceAsync(uri, cancellationToken);
@@ -33,8 +33,8 @@ public static class ByteSourceUriExtensions
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A Result with the ByteSource if the operation is successful</returns>
     public static async Task<Result<IByteSource>> ToByteSource(
-        this Uri uri, 
-        HttpClient httpClient, 
+        this Uri uri,
+        HttpClient httpClient,
         CancellationToken cancellationToken = default)
     {
         return await ByteSourceUriFactoryMethods.FromUri(uri, httpClient, cancellationToken);
@@ -54,8 +54,8 @@ public static class StringUriExtensions
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A Result with the ByteSource if the operation is successful</returns>
     public static async Task<Result<IByteSource>> ToByteSource(
-        this string uriString, 
-        IUriContentProvider contentProvider, 
+        this string uriString,
+        IUriContentProvider contentProvider,
         CancellationToken cancellationToken = default)
     {
         if (!Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
@@ -75,8 +75,8 @@ public static class StringUriExtensions
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A Result with the ByteSource if the operation is successful</returns>
     public static async Task<Result<IByteSource>> ToByteSource(
-        this string uriString, 
-        HttpClient httpClient, 
+        this string uriString,
+        HttpClient httpClient,
         CancellationToken cancellationToken = default)
     {
         return await ByteSourceUriFactoryMethods.FromUri(uriString, httpClient, cancellationToken);

--- a/src/Zafiro.DivineBytes/ByteSourceUriFactoryMethods.cs
+++ b/src/Zafiro.DivineBytes/ByteSourceUriFactoryMethods.cs
@@ -17,8 +17,8 @@ public static class ByteSourceUriFactoryMethods
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A Result with the ByteSource if the operation is successful</returns>
     public static async Task<Result<IByteSource>> FromUri(
-        Uri uri, 
-        HttpClient httpClient, 
+        Uri uri,
+        HttpClient httpClient,
         CancellationToken cancellationToken = default)
     {
         var contentProvider = new HttpUriContentProvider(httpClient);
@@ -34,8 +34,8 @@ public static class ByteSourceUriFactoryMethods
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A Result with the ByteSource if the operation is successful</returns>
     public static async Task<Result<IByteSource>> FromUri(
-        this string uriString, 
-        HttpClient httpClient, 
+        this string uriString,
+        HttpClient httpClient,
         CancellationToken cancellationToken = default)
     {
         if (!Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
@@ -55,7 +55,7 @@ public static class ByteSourceUriFactoryMethods
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A Result with the ByteSource if the operation is successful</returns>
     public static Task<Result<IByteSource>> FromUri(
-        this Uri uri, 
+        this Uri uri,
         CancellationToken cancellationToken = default)
     {
         try
@@ -74,7 +74,7 @@ public static class ByteSourceUriFactoryMethods
                 {
                     var response = await httpClient.GetAsync(uri, cancellationToken);
                     response.EnsureSuccessStatusCode();
-                    
+
                     // Create a wrapper that disposes both the HttpClient and the HttpResponseMessage
                     var responseStream = await HttpResponseMessageStream.Create(response);
                     return new HttpClientOwningStream(responseStream, httpClient);
@@ -103,7 +103,7 @@ public static class ByteSourceUriFactoryMethods
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A Result with the ByteSource if the operation is successful</returns>
     public static async Task<Result<IByteSource>> FromUri(
-        string uriString, 
+        string uriString,
         CancellationToken cancellationToken = default)
     {
         if (!Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
@@ -147,10 +147,10 @@ public static class ByteSourceUriFactoryMethods
         public override bool CanSeek => innerStream.CanSeek;
         public override bool CanWrite => innerStream.CanWrite;
         public override long Length => innerStream.Length;
-        public override long Position 
-        { 
-            get => innerStream.Position; 
-            set => innerStream.Position = value; 
+        public override long Position
+        {
+            get => innerStream.Position;
+            set => innerStream.Position = value;
         }
 
         public override void Flush() => innerStream.Flush();

--- a/src/Zafiro.DivineBytes/Container.cs
+++ b/src/Zafiro.DivineBytes/Container.cs
@@ -12,13 +12,13 @@ public class Container : INamedContainer
         Resources = files.ToList();
         Subcontainers = directories.ToList();
     }
-    
+
     // Static factory method for fluent syntax
     public static Container Create(string name, IEnumerable<INamedByteSource> resources, IEnumerable<INamedContainer> subcontainers)
     {
         return new Container(name, resources, subcontainers);
     }
-    
+
     // Constructor that accepts mixed content and separates by type
     public Container(string name, params INamed[] contents)
     {
@@ -26,7 +26,7 @@ public class Container : INamedContainer
         Resources = contents.OfType<INamedByteSource>().ToList();
         Subcontainers = contents.OfType<INamedContainer>().ToList();
     }
-    
+
     // Method to show structure
     public override string ToString()
     {

--- a/src/Zafiro.DivineBytes/ContainerExtensions.cs
+++ b/src/Zafiro.DivineBytes/ContainerExtensions.cs
@@ -15,7 +15,7 @@ public static class ContainerExtensions
         return files.ToDirectoryTree()
             .Map(container => new RootContainer(container.Resources, container.Subcontainers));
     }
-    
+
     /// <summary>
     /// Create a named container from a root container
     /// </summary>
@@ -23,7 +23,7 @@ public static class ContainerExtensions
     {
         return new NamedContainer(name, root.Resources, root.Subcontainers);
     }
-    
+
     /// <summary>
     /// Create a named container from an existing container
     /// </summary>
@@ -31,7 +31,7 @@ public static class ContainerExtensions
     {
         return new NamedContainer(name, container.Resources, container.Subcontainers);
     }
-    
+
     /// <summary>
     /// Convert any container to a root container
     /// </summary>
@@ -39,7 +39,7 @@ public static class ContainerExtensions
     {
         return new RootContainer(container.Resources, container.Subcontainers);
     }
-    
+
     /// <summary>
     /// Convert root container to IContainer for compatibility with existing code
     /// </summary>
@@ -47,7 +47,7 @@ public static class ContainerExtensions
     {
         return new Container("", root.Resources, root.Subcontainers);
     }
-    
+
     public static Task<Result> WriteTo(this IContainer container, string path)
     {
         return container.ResourcesWithPathsRecursive()

--- a/src/Zafiro.DivineBytes/DictionaryToContainerExtensions.cs
+++ b/src/Zafiro.DivineBytes/DictionaryToContainerExtensions.cs
@@ -33,7 +33,7 @@ public static class DictionaryToContainerExtensions
                 }
 
                 var pathParts = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
-                
+
                 if (pathParts.Length == 1)
                 {
                     // This is a file directly in the root
@@ -45,12 +45,12 @@ public static class DictionaryToContainerExtensions
                     // This is a nested path, group by first directory
                     var firstDir = pathParts[0];
                     var remainingPath = string.Join("/", pathParts.Skip(1));
-                    
+
                     if (!directoryGroups.ContainsKey(firstDir))
                     {
                         directoryGroups[firstDir] = new List<(string, IByteSource)>();
                     }
-                    
+
                     directoryGroups[firstDir].Add((remainingPath, content));
                 }
             }

--- a/src/Zafiro.DivineBytes/DirectoryContentsExtensions.cs
+++ b/src/Zafiro.DivineBytes/DirectoryContentsExtensions.cs
@@ -10,7 +10,7 @@ public static class DirectoryContentsExtensions
         path ??= Path.Empty;
         // Include files as INamedByteSourceWithPath (which implements INamedWithPath)
         var myResoruces = container.Resources.Select(file => new ResourceWithPath(path, file));
-        
+
         // Include subdirectories as INamedWithPath and recursively their children
         var subcontainerResults = container.Subcontainers.SelectMany(subcontainer =>
         {

--- a/src/Zafiro.DivineBytes/HttpUriContentProvider.cs
+++ b/src/Zafiro.DivineBytes/HttpUriContentProvider.cs
@@ -40,7 +40,7 @@ public class HttpUriContentProvider : IUriContentProvider, IDisposable
 
             // Validate that the URI is accessible without creating a ByteSource yet
             using var testResponse = await httpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            
+
             if (!testResponse.IsSuccessStatusCode)
             {
                 return Result.Failure<IByteSource>($"Error downloading from {uri}: {testResponse.StatusCode} - {testResponse.ReasonPhrase}");
@@ -51,7 +51,7 @@ public class HttpUriContentProvider : IUriContentProvider, IDisposable
             {
                 var response = await httpClient.GetAsync(uri, cancellationToken);
                 response.EnsureSuccessStatusCode();
-                
+
                 return await HttpResponseMessageStream.Create(response);
             });
 

--- a/src/Zafiro.DivineBytes/NamedContainer.cs
+++ b/src/Zafiro.DivineBytes/NamedContainer.cs
@@ -14,17 +14,17 @@ public class NamedContainer : INamedContainer
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("Named container must have a non-empty name", nameof(name));
-        
+
         Name = name;
         Resources = resources.ToList();
         Subcontainers = subcontainers.ToList();
     }
-    
+
     public NamedContainer(string name, params INamed[] contents)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("Named container must have a non-empty name", nameof(name));
-        
+
         Name = name;
         Resources = contents.OfType<INamedByteSource>().ToList();
         Subcontainers = contents.OfType<INamedContainer>().ToList();

--- a/src/Zafiro.DivineBytes/System.IO/DirectoryContainer.cs
+++ b/src/Zafiro.DivineBytes/System.IO/DirectoryContainer.cs
@@ -5,12 +5,12 @@ namespace Zafiro.DivineBytes.System.IO;
 public class DirectoryContainer(IDirectoryInfo directoryInfo) : INamedContainer
 {
     public string Name => directoryInfo.Name;
-    
+
     // Implement new IContainer interface
     public IEnumerable<INamedContainer> Subcontainers => directoryInfo
         .GetDirectories()
         .Select(info => new DirectoryContainer(info));
-        
+
     public IEnumerable<INamedByteSource> Resources => directoryInfo
         .GetFiles()
         .Select(info => new FileResource(info));

--- a/src/Zafiro.DivineBytes/Unix/UnixDirectory.cs
+++ b/src/Zafiro.DivineBytes/Unix/UnixDirectory.cs
@@ -13,7 +13,7 @@ public class UnixDirectory : INamedContainer, IPermissioned, IOwned
     public IEnumerable<INamedByteSource> Resources => Files;
 
     // Keep Children for backward compatibility if needed
-    public IEnumerable<INamed> Children 
+    public IEnumerable<INamed> Children
         => Subdirectories.Cast<INamed>().Concat(Files);
 
     public UnixDirectory(
@@ -23,11 +23,11 @@ public class UnixDirectory : INamedContainer, IPermissioned, IOwned
         IEnumerable<UnixDirectory> subdirs,
         IEnumerable<UnixFile> files)
     {
-        Name           = name;
+        Name = name;
         OwnerId = ownerId;
-        Permissions    = permissions;
+        Permissions = permissions;
         Subdirectories = subdirs.ToList();
-        Files          = files.ToList();
+        Files = files.ToList();
     }
 
     public int OwnerId { get; }

--- a/src/Zafiro.DivineBytes/Unix/UnixFile.cs
+++ b/src/Zafiro.DivineBytes/Unix/UnixFile.cs
@@ -10,14 +10,14 @@ public class UnixFile : INamedByteSource, IPermissioned, IOwned
 
     public UnixFile(INamedByteSource inner, UnixPermissions perms, int ownerId)
     {
-        this.inner      = inner;
+        this.inner = inner;
         Permissions = perms;
         OwnerId = ownerId;
     }
 
     public IObservable<byte[]> Bytes
-        => Permissions.OwnerRead 
-            ? inner.Bytes 
+        => Permissions.OwnerRead
+            ? inner.Bytes
             : Observable.Empty<byte[]>();
 
     public IDisposable Subscribe(IObserver<byte[]> observer)

--- a/src/Zafiro.DivineBytes/Unix/UnixPermissions.cs
+++ b/src/Zafiro.DivineBytes/Unix/UnixPermissions.cs
@@ -13,7 +13,7 @@ public enum Permission
     OtherRead = 1 << 6,   // 64
     OtherWrite = 1 << 7,  // 128
     OtherExec = 1 << 8,   // 256
-    
+
     // Combinaciones comunes
     OwnerAll = OwnerRead | OwnerWrite | OwnerExec,
     GroupAll = GroupRead | GroupWrite | GroupExec,
@@ -26,50 +26,50 @@ public enum Permission
 
 public struct UnixPermissions
 {
-    public bool OwnerRead   { get; }
-    public bool OwnerWrite  { get; }
-    public bool OwnerExec   { get; }
-    public bool GroupRead   { get; }
-    public bool GroupWrite  { get; }
-    public bool GroupExec   { get; }
-    public bool OtherRead   { get; }
-    public bool OtherWrite  { get; }
-    public bool OtherExec   { get; }
+    public bool OwnerRead { get; }
+    public bool OwnerWrite { get; }
+    public bool OwnerExec { get; }
+    public bool GroupRead { get; }
+    public bool GroupWrite { get; }
+    public bool GroupExec { get; }
+    public bool OtherRead { get; }
+    public bool OtherWrite { get; }
+    public bool OtherExec { get; }
 
     public UnixPermissions(bool ownerRead, bool ownerWrite, bool ownerExec,
         bool groupRead, bool groupWrite, bool groupExec,
         bool otherRead, bool otherWrite, bool otherExec)
     {
-        OwnerRead  = ownerRead;
+        OwnerRead = ownerRead;
         OwnerWrite = ownerWrite;
-        OwnerExec  = ownerExec;
-        GroupRead  = groupRead;
+        OwnerExec = ownerExec;
+        GroupRead = groupRead;
         GroupWrite = groupWrite;
-        GroupExec  = groupExec;
-        OtherRead  = otherRead;
+        GroupExec = groupExec;
+        OtherRead = otherRead;
         OtherWrite = otherWrite;
-        OtherExec  = otherExec;
+        OtherExec = otherExec;
     }
 
     // Constructor más cómodo usando flags
     public UnixPermissions(Permission permissions)
     {
-        OwnerRead  = permissions.HasFlag(Permission.OwnerRead);
+        OwnerRead = permissions.HasFlag(Permission.OwnerRead);
         OwnerWrite = permissions.HasFlag(Permission.OwnerWrite);
-        OwnerExec  = permissions.HasFlag(Permission.OwnerExec);
-        GroupRead  = permissions.HasFlag(Permission.GroupRead);
+        OwnerExec = permissions.HasFlag(Permission.OwnerExec);
+        GroupRead = permissions.HasFlag(Permission.GroupRead);
         GroupWrite = permissions.HasFlag(Permission.GroupWrite);
-        GroupExec  = permissions.HasFlag(Permission.GroupExec);
-        OtherRead  = permissions.HasFlag(Permission.OtherRead);
+        GroupExec = permissions.HasFlag(Permission.GroupExec);
+        OtherRead = permissions.HasFlag(Permission.OtherRead);
         OtherWrite = permissions.HasFlag(Permission.OtherWrite);
-        OtherExec  = permissions.HasFlag(Permission.OtherExec);
+        OtherExec = permissions.HasFlag(Permission.OtherExec);
     }
 
     // Método para obtener los permisos como flags
     public Permission ToPermission()
     {
         Permission result = Permission.None;
-        
+
         if (OwnerRead) result |= Permission.OwnerRead;
         if (OwnerWrite) result |= Permission.OwnerWrite;
         if (OwnerExec) result |= Permission.OwnerExec;
@@ -79,7 +79,7 @@ public struct UnixPermissions
         if (OtherRead) result |= Permission.OtherRead;
         if (OtherWrite) result |= Permission.OtherWrite;
         if (OtherExec) result |= Permission.OtherExec;
-        
+
         return result;
     }
 

--- a/src/Zafiro.FileSystem.Unix/UnixFilePermissionsMixin.cs
+++ b/src/Zafiro.FileSystem.Unix/UnixFilePermissionsMixin.cs
@@ -32,7 +32,7 @@ public static class UnixFilePermissionsMixin
 
         return mode;
     }
-    
+
     public static string ToFileModeString(this UnixFileMode mode)
     {
         // Convertimos los permisos individuales

--- a/src/Zafiro.FileSystem.Unix/UnixFileProperties.cs
+++ b/src/Zafiro.FileSystem.Unix/UnixFileProperties.cs
@@ -8,7 +8,7 @@ public record UnixFileProperties
     public required Maybe<string> GroupName { get; init; }
     public required Maybe<int> OwnerId { get; init; }
     public required Maybe<int> GroupId { get; init; }
-    
+
     public static UnixFileProperties RegularFileProperties() => new()
     {
         FileMode = "644".ToFileMode(),
@@ -18,7 +18,7 @@ public record UnixFileProperties
         OwnerUsername = "root",
         LastModification = DateTimeOffset.Now
     };
-    
+
     public static UnixFileProperties RegularDirectoryProperties() => new()
     {
         FileMode = "755".ToFileMode(),

--- a/src/Zafiro.FileSystem.Unix/UnixRoot.cs
+++ b/src/Zafiro.FileSystem.Unix/UnixRoot.cs
@@ -5,7 +5,7 @@ public class UnixRoot : UnixDir
     public UnixRoot() : base("")
     {
     }
-    
+
     public UnixRoot(IEnumerable<UnixNode> nodes) : base("", nodes)
     {
     }

--- a/src/Zafiro.FileSystem/Core/HashCompareStrategy.cs
+++ b/src/Zafiro.FileSystem/Core/HashCompareStrategy.cs
@@ -8,10 +8,10 @@ public class HashCompareStrategy : IFileCompareStrategy
     public async Task<Result<bool>> Compare(IZafiroFile one, IZafiroFile another)
     {
         var areEqual = await from leftHashes in one.Hashes
-            from rightHashes in another.Hashes
-            select from leftHash in leftHashes
-                join rightHash in rightHashes on leftHash.Key equals rightHash.Key
-                select new { LeftHash = leftHash, RightHash = rightHash };
+                             from rightHashes in another.Hashes
+                             select from leftHash in leftHashes
+                                    join rightHash in rightHashes on leftHash.Key equals rightHash.Key
+                                    select new { LeftHash = leftHash, RightHash = rightHash };
 
         return areEqual.Map(x => x.Any(combination => StructuralComparisons.StructuralEqualityComparer.Equals(combination.LeftHash.Value, combination.RightHash.Value)));
     }

--- a/src/Zafiro.FileSystem/Core/Mixin.cs
+++ b/src/Zafiro.FileSystem/Core/Mixin.cs
@@ -27,8 +27,8 @@ public static class Mixin
             .CombineSequentially();
 
         return from file in files
-            from subdir in subDirs
-            select (IDirectory)new Directory(directory.Name, file.Concat(subdir.Cast<INode>()));
+               from subdir in subDirs
+               select (IDirectory)new Directory(directory.Name, file.Concat(subdir.Cast<INode>()));
     }
 
     public static Stream ToStream(this IFile file)

--- a/src/Zafiro.FileSystem/Mutable/MutableMixin.cs
+++ b/src/Zafiro.FileSystem/Mutable/MutableMixin.cs
@@ -39,7 +39,7 @@ public static class MutableMixin
         return directory.CreateFile(name)
             .Bind(f => f.SetContents(data));
     }
-    
+
     public static Task<Result> CreateFileWithContents(this IMutableDirectory directory, IFile file)
     {
         return directory.CreateFile(file.Name)

--- a/src/Zafiro.FileSystem/Readonly/Mixin.cs
+++ b/src/Zafiro.FileSystem/Readonly/Mixin.cs
@@ -13,7 +13,7 @@ public static class Mixin
     {
         return directory.RootedFilesRelativeTo(ZafiroPath.Empty);
     }
-    
+
     public static IEnumerable<IFile> AllFiles(this IDirectory directory)
     {
         return directory.Files().Concat(directory.Directories().SelectMany(d => d.AllFiles()));

--- a/src/Zafiro/CSharpFunctionalExtensions/FunctionalMixin.cs
+++ b/src/Zafiro/CSharpFunctionalExtensions/FunctionalMixin.cs
@@ -23,7 +23,7 @@ public static class FunctionalMixin
         var enumerable = await self.ConfigureAwait(false);
         return enumerable.Successes();
     }
-    
+
     public static IObservable<Unit> Successes(this IObservable<Result> self)
     {
         return self.Where(a => a.IsSuccess).ToSignal();
@@ -254,7 +254,7 @@ public static class FunctionalMixin
     {
         return task.Bind(tasks => CombineSequentially(tasks, scheduler));
     }
-    
+
     public static Task<Result> CombineSequentially(this Task<Result<IEnumerable<Task<Result>>>> task, IScheduler? scheduler = default)
     {
         return task.Bind(tasks => CombineSequentially(tasks, scheduler));
@@ -279,7 +279,7 @@ public static class FunctionalMixin
 
         return results.Combine();
     }
-    
+
     public static async Task<IEnumerable<Result<TResult>>> Concat<TResult>(this IEnumerable<Task<Result<TResult>>> enumerableOfTaskResults, IScheduler? scheduler = default, int maxConcurrency = 1)
     {
         var results = await enumerableOfTaskResults
@@ -307,7 +307,7 @@ public static class FunctionalMixin
     {
         return taskResult.Bind(inputs => AsyncResultExtensionsLeftOperand.Combine(inputs.Select(selector)));
     }
-    
+
     /// <summary>
     /// Transforms each input value using the provided transform function and combines all results with controlled concurrency.
     /// This is equivalent to MapEach followed by Combine. All transformations must succeed for the operation to succeed.
@@ -332,7 +332,7 @@ public static class FunctionalMixin
     {
         return result.MapEach(transform).Combine(scheduler, maxConcurrency);
     }
-    
+
     /// <summary>
     /// Transforms each input value using the provided transform function and combines all results sequentially.
     /// This guarantees that transformations are executed one after another in order, which is useful when order matters
@@ -361,7 +361,7 @@ public static class FunctionalMixin
     public static void Log(this Result result, ILogger? logger = default, string successString = "Success")
     {
         logger ??= Serilog.Log.Logger;
-        
+
         result
             .Tap(() => logger.Information(successString))
             .TapError(logger.Error);
@@ -371,7 +371,7 @@ public static class FunctionalMixin
     {
         (await result.ConfigureAwait(false)).Log(logger ?? Serilog.Log.Logger, successString);
     }
-    
+
     /// <summary>
     /// Returns the result of the task or, if the specified time elapses without completion,
     /// a failed Result indicating timeout.
@@ -400,7 +400,7 @@ public static class FunctionalMixin
         // Timeout was reached
         return Result.Failure<T>(message);
     }
-    
+
     public static Task<Result<Maybe<T>>> TryFirstResult<T>(this IEnumerable<T> source, Func<T, Task<Result<bool>>> predicate)
     {
         // Assuming the application root contains a single ELF executable
@@ -409,7 +409,7 @@ public static class FunctionalMixin
             .Map(bools => bools.TryFirst(tuple => tuple.Matches)
                 .Select(tuple => tuple.Item));
     }
-    
+
     public static Task<Result<T>> ToResult<T>(this Task<Result<Maybe<T>>> resultOfmaybe, string errorMessage)
     {
         return resultOfmaybe.Bind(x => x.ToResult(errorMessage));

--- a/src/Zafiro/CSharpFunctionalExtensions/ReactiveResultMixin.cs
+++ b/src/Zafiro/CSharpFunctionalExtensions/ReactiveResultMixin.cs
@@ -387,7 +387,7 @@ namespace Zafiro.CSharpFunctionalExtensions
         public static IObservable<Result<T>> ToResult<T>(this IObservable<T> source, string? errorMessage = null)
         {
             return source.Select(Result.Success)
-                .Catch<Result<T>, Exception>(ex => 
+                .Catch<Result<T>, Exception>(ex =>
                     Observable.Return(Result.Failure<T>(errorMessage ?? ex.Message)));
         }
 
@@ -403,12 +403,12 @@ namespace Zafiro.CSharpFunctionalExtensions
         /// <remarks>
         /// Essential for ensuring responsiveness in reactive sequences that may stall.
         /// </remarks>
-        public static IObservable<Result<T>> WithTimeout<T>(this IObservable<Result<T>> source, 
+        public static IObservable<Result<T>> WithTimeout<T>(this IObservable<Result<T>> source,
             TimeSpan timeout,
             string? timeoutMessage = null)
         {
             return source.Timeout(timeout)
-                .Catch<Result<T>, TimeoutException>(_ => 
+                .Catch<Result<T>, TimeoutException>(_ =>
                     Observable.Return(Result.Failure<T>(timeoutMessage ?? "Operation timed out")));
         }
     }

--- a/src/Zafiro/Commands/Command.cs
+++ b/src/Zafiro/Commands/Command.cs
@@ -44,15 +44,15 @@ public class Command(Maybe<ILogger> logger) : ICommand
         process.Start();
 
         var outputTask = ReadStreamAsync(process.StandardOutput);
-        var errorTask  = ReadStreamAsync(process.StandardError);
+        var errorTask = ReadStreamAsync(process.StandardError);
 
         await Task.WhenAll(outputTask, errorTask);
         await process.WaitForExitAsync();
 
-        var output         = outputTask.Result;
-        var error          = errorTask.Result;
+        var output = outputTask.Result;
+        var error = errorTask.Result;
         var combinedOutput = BuildCombinedLogMessage(output, error);
-        combinedOutput     = SanitizeSensitiveInfo(combinedOutput);
+        combinedOutput = SanitizeSensitiveInfo(combinedOutput);
 
         if (process.ExitCode == 0)
         {

--- a/src/Zafiro/DataAnalysis/Clustering/ICluster.cs
+++ b/src/Zafiro/DataAnalysis/Clustering/ICluster.cs
@@ -5,7 +5,7 @@ namespace Zafiro.DataAnalysis.Clustering;
 public interface ICluster
 {
     public object? Item { get; }
-    public ICluster? Parent { get;}
+    public ICluster? Parent { get; }
     public ICluster? Left { get; }
     public ICluster? Right { get; }
     public double MergeDistance { get; }

--- a/src/Zafiro/DataAnalysis/Graphs/ForceDirected/ForceDirectedEngine.cs
+++ b/src/Zafiro/DataAnalysis/Graphs/ForceDirected/ForceDirectedEngine.cs
@@ -104,8 +104,8 @@ public class ForceDirectedEngine(IMutableGraph mutableGraph) : IEngine
     {
         Nodes.ForEach(x =>
         {
-            x.X = Random.Shared.Next((int) width);
-            x.Y = Random.Shared.Next((int) height);
+            x.X = Random.Shared.Next((int)width);
+            x.Y = Random.Shared.Next((int)height);
         });
     }
 }

--- a/src/Zafiro/DataAnalysis/HeatmapWithDendrograms.cs
+++ b/src/Zafiro/DataAnalysis/HeatmapWithDendrograms.cs
@@ -17,7 +17,7 @@ public class HeatmapWithDendrograms(ICluster rowsCluster, ICluster columnsCluste
         var clusterTableColumns = columnDistances.ToClusterTable();
         var columnsCluster = columnClusteringStrategy.Clusterize(clusterTableColumns);
         var columnOrder = MoreEnumerable.TraverseDepthFirst(columnsCluster,
-        node => node is Internal<TColumn> i ? new[] {i.Left, i.Right} : Enumerable.Empty<Cluster<TColumn>>())
+        node => node is Internal<TColumn> i ? new[] { i.Left, i.Right } : Enumerable.Empty<Cluster<TColumn>>())
         .OfType<Leaf<TColumn>>()
         .Select(x => x.Item)
         .ToList();
@@ -26,7 +26,7 @@ public class HeatmapWithDendrograms(ICluster rowsCluster, ICluster columnsCluste
         var clusterTableRows = rowDistances.ToClusterTable();
         var rowsCluster = rowClusteringStrategy.Clusterize(clusterTableRows);
         var rowOrder = MoreEnumerable.TraverseDepthFirst(rowsCluster,
-                node => node is Internal<TRow> i ? new[] {i.Left, i.Right} : Enumerable.Empty<Cluster<TRow>>())
+                node => node is Internal<TRow> i ? new[] { i.Left, i.Right } : Enumerable.Empty<Cluster<TRow>>())
             .OfType<Leaf<TRow>>()
             .Select(x => x.Item)
             .ToList();

--- a/src/Zafiro/MethodFinder.cs
+++ b/src/Zafiro/MethodFinder.cs
@@ -19,10 +19,10 @@ public static class MethodFinder
         var allMethods = fromInterfaces.Concat(fromType);
 
         var matching = from method in allMethods
-            where method.Name == name
-            where HasCorrectArgumentTypes(method, parameterTypes)
-            where !method.IsStatic
-            select method;
+                       where method.Name == name
+                       where HasCorrectArgumentTypes(method, parameterTypes)
+                       where !method.IsStatic
+                       select method;
 
         return matching.FirstOrDefault();
     }

--- a/src/Zafiro/Misc/DefaultHttpClientFactory.cs
+++ b/src/Zafiro/Misc/DefaultHttpClientFactory.cs
@@ -15,7 +15,7 @@ public sealed class DefaultHttpClientFactory : IHttpClientFactory, IDisposable
         {
             return;
         }
-        
+
         handlerLazy.Value.Dispose();
     }
 }

--- a/src/Zafiro/Misc/LogMixin.cs
+++ b/src/Zafiro/Misc/LogMixin.cs
@@ -10,29 +10,29 @@ public static class LogMixin
     public static Result LogInfo(this Result result, string str, params object[] propertyValues) => result
         .Tap(() => Log.Information(str, propertyValues))
         .TapError(Log.Error);
-    
+
     public static Result LogError(this Result result, Func<string, (string, object[] propertyValues)> getError) => result
         .TapError(error =>
         {
             var valueTuple = getError(error);
             Log.Error(valueTuple.Item1, valueTuple.propertyValues);
         });
-    
+
     public static Result<T> LogError<T>(this Result<T> result, Func<string, (string, object[] propertyValues)> getError) => result
         .TapError(error =>
         {
             var valueTuple = getError(error);
             Log.Error(valueTuple.Item1, valueTuple.propertyValues);
         });
-    
+
     public static Result<T> LogInfo<T>(this Result<T> result, string str, params object[] propertyValues) => result
         .Tap(() => Log.Information(str, propertyValues))
         .TapError(Log.Error);
-    
+
     public static Task<Result<T>> LogInfo<T>(this Task<Result<T>> result, string str, params object[] propertyValues) => result
         .Tap(() => Log.Information(str, propertyValues))
         .TapError(Log.Error);
-    
+
     public static Task<Result> LogInfo(this Task<Result> result, string str, params object[] propertyValues) => result
         .Tap(() => Log.Information(str, propertyValues))
         .TapError(Log.Error);

--- a/src/Zafiro/Misc/StringUtil.cs
+++ b/src/Zafiro/Misc/StringUtil.cs
@@ -13,12 +13,12 @@ public static class StringUtil
         async Task<Result<string>> TryName(string name, string current, int i)
         {
             var result = await isValid(current);
-        
-            return result is { IsSuccess: true, Value: true } 
-                ? Result.Success(current) 
-                : result.IsFailure 
-                    ? result.ConvertFailure<string>() 
-                    : await TryName(seed, generateNewName(seed, i + 1), i+1);
+
+            return result is { IsSuccess: true, Value: true }
+                ? Result.Success(current)
+                : result.IsFailure
+                    ? result.ConvertFailure<string>()
+                    : await TryName(seed, generateNewName(seed, i + 1), i + 1);
         }
     }
 }

--- a/src/Zafiro/Mixins/ArrayMixin.cs
+++ b/src/Zafiro/Mixins/ArrayMixin.cs
@@ -9,9 +9,9 @@ public static class ArrayMixin
     public static byte[] ToByteArray(this int[] buffer)
     {
         var q = from i in buffer
-            let bytes = GetBytes(i)
-            from b in bytes
-            select b;
+                let bytes = GetBytes(i)
+                from b in bytes
+                select b;
 
         return q.ToArray();
     }
@@ -19,7 +19,7 @@ public static class ArrayMixin
     public static int[] ToIntArray(this byte[] buffer)
     {
         var q = from b in buffer.Chunkify(sizeof(int))
-            select BitConverter.ToInt32(b.ToArray(), 0);
+                select BitConverter.ToInt32(b.ToArray(), 0);
 
         return q.ToArray();
     }

--- a/src/Zafiro/Mixins/Extensions.cs
+++ b/src/Zafiro/Mixins/Extensions.cs
@@ -74,9 +74,9 @@ public static class Extensions
         where TAttribute : Attribute
     {
         return from type in types
-            let att = type.GetTypeInfo().GetCustomAttribute<TAttribute>()
-            where att != null
-            select converter(type, att);
+               let att = type.GetTypeInfo().GetCustomAttribute<TAttribute>()
+               where att != null
+               select converter(type, att);
     }
 
     public static IEnumerable<TResult> GatherAttributesFromMembers<TAttribute, TResult>(
@@ -85,10 +85,10 @@ public static class Extensions
         where TAttribute : Attribute
     {
         return from type in types
-            from member in type.GetRuntimeProperties()
-            let att = member.GetCustomAttribute<TAttribute>()
-            where att != null
-            select converter(member, att);
+               from member in type.GetRuntimeProperties()
+               let att = member.GetCustomAttribute<TAttribute>()
+               where att != null
+               select converter(member, att);
     }
 
     public static IEnumerable<IEnumerable<T>> Chunkify<T>(this IEnumerable<T> source,

--- a/src/Zafiro/Mixins/LoggerExtensions.cs
+++ b/src/Zafiro/Mixins/LoggerExtensions.cs
@@ -17,7 +17,7 @@ public static class LoggerExtensions
 
     public static void Error(this Maybe<ILogger> maybeLogger, string message, params object[] args)
         => maybeLogger.Execute(logger => logger.Error(message, args));
-    
+
     public static void Error(this Maybe<ILogger> maybeLogger, Exception exception, string message, params object[] args)
         => maybeLogger.Execute(logger => logger.Error(exception, message, args));
 }

--- a/src/Zafiro/Mixins/TypeExtensions.cs
+++ b/src/Zafiro/Mixins/TypeExtensions.cs
@@ -28,9 +28,9 @@ public static class TypeExtensions
     public static TSelector GetAttributeFromProperty<TAttribute, TSelector>(this Type type, Func<PropertyInfo, TAttribute, TSelector> selector) where TAttribute : Attribute
     {
         var attributes = from prop in type.GetRuntimeProperties()
-            let attr = prop.GetCustomAttribute<TAttribute>()
-            where attr != null
-            select new { prop, attr };
+                         let attr = prop.GetCustomAttribute<TAttribute>()
+                         where attr != null
+                         select new { prop, attr };
 
         var single = attributes.FirstOrDefault();
 
@@ -40,9 +40,9 @@ public static class TypeExtensions
     public static IEnumerable<TSelector> GetAttributesFromProperties<TAttribute, TSelector>(this Type type, Func<PropertyInfo, TAttribute, TSelector> selector) where TAttribute : Attribute
     {
         var attributes = from prop in type.GetRuntimeProperties()
-            let attr = prop.GetCustomAttribute<TAttribute>()
-            where attr != null
-            select new { prop, attr };
+                         let attr = prop.GetCustomAttribute<TAttribute>()
+                         where attr != null
+                         select new { prop, attr };
 
         return attributes.Select(arg => selector(arg.prop, arg.attr));
     }

--- a/src/Zafiro/Reactive/DynamicDataMixin.cs
+++ b/src/Zafiro/Reactive/DynamicDataMixin.cs
@@ -37,7 +37,7 @@ public static class DynamicDataMixin
             {
                 throw new InvalidOperationException("ToObservableChangeSetIfPossible returned null");
             }
-            
+
             return observable;
         }
 

--- a/src/Zafiro/Reactive/ResetableObservableStream.cs
+++ b/src/Zafiro/Reactive/ResetableObservableStream.cs
@@ -17,7 +17,7 @@ public class ResetableObservableStream(IObservable<byte[]> observable) : Stream
     public override bool CanRead => !isDisposed;
     public override bool CanSeek => !isDisposed;
     public override bool CanWrite => false;
-        
+
     public override long Length
     {
         get
@@ -30,10 +30,10 @@ public class ResetableObservableStream(IObservable<byte[]> observable) : Stream
             }
         }
     }
-        
-    public override long Position 
-    { 
-        get 
+
+    public override long Position
+    {
+        get
         {
             ThrowIfDisposed();
             lock (lockObject)
@@ -53,7 +53,7 @@ public class ResetableObservableStream(IObservable<byte[]> observable) : Stream
 
         ThrowIfDisposed();
         EnsureDataLoaded();
-            
+
         lock (lockObject)
         {
             if (loadException != null)
@@ -87,7 +87,7 @@ public class ResetableObservableStream(IObservable<byte[]> observable) : Stream
             Exception? exception = null;
 
             using var subscription = observable.Subscribe(
-                onNext: data => 
+                onNext: data =>
                 {
                     lock (lockObject)
                     {
@@ -136,7 +136,7 @@ public class ResetableObservableStream(IObservable<byte[]> observable) : Stream
     {
         ThrowIfDisposed();
         EnsureDataLoaded();
-            
+
         lock (lockObject)
         {
             var newPosition = origin switch
@@ -149,7 +149,7 @@ public class ResetableObservableStream(IObservable<byte[]> observable) : Stream
 
             if (newPosition < 0)
                 throw new ArgumentOutOfRangeException(nameof(offset), "Seek position cannot be negative");
-                
+
             if (newPosition > (cachedData?.Length ?? 0))
                 newPosition = cachedData?.Length ?? 0;
 

--- a/src/Zafiro/Tables/Extensions.cs
+++ b/src/Zafiro/Tables/Extensions.cs
@@ -65,7 +65,7 @@ public static class Extensions
 
         return new Table<TItem, TValue>(matrix, labels);
     }
-    
+
     public static TaggedEnumerable<TCell, TRow> GetRow<TRow, TColumn, TCell>(this Table<TRow, TColumn, TCell> table,
         TRow row) where TCell : notnull where TRow : notnull
     {
@@ -207,7 +207,7 @@ public static class Extensions
             for (var c = 0; c < table.Columns; c++)
             {
                 yield return table.Matrix[i, c];
-            }    
+            }
         }
     }
 }

--- a/src/Zafiro/Tables/Table.cs
+++ b/src/Zafiro/Tables/Table.cs
@@ -9,7 +9,7 @@ namespace Zafiro.Tables;
 
 public class Table<TLabel, TCell>(TCell[,] matrix, IList<TLabel> labels) : Table<TLabel, TLabel, TCell>(matrix, labels, labels) where TCell : notnull;
 
-public class Table<TRow, TColumn, TCell> : ITable where TCell: notnull
+public class Table<TRow, TColumn, TCell> : ITable where TCell : notnull
 {
     public TCell[,] Matrix { get; }
     object[,] ITable.Matrix => GetObjectMatrix();

--- a/src/Zafiro/UI/ObjectEditor/PropertyItem.cs
+++ b/src/Zafiro/UI/ObjectEditor/PropertyItem.cs
@@ -52,11 +52,11 @@ public abstract class PropertyItem<T> : ReactiveObject, IDisposable
     private void SubscribeToPropertyChangesOf(IEnumerable<INotifyPropertyChanged> observables)
     {
         var subscriptions = from observable in observables
-            let subscription =
-                Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
-                        h => observable.PropertyChanged += h, h => PropertyChanged -= h)
-                    .Subscribe(args => OnTargetPropertyChanged(args.EventArgs.PropertyName))
-            select subscription;
+                            let subscription =
+                                Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                                        h => observable.PropertyChanged += h, h => PropertyChanged -= h)
+                                    .Subscribe(args => OnTargetPropertyChanged(args.EventArgs.PropertyName))
+                            select subscription;
 
         foreach (var subscription in subscriptions) disposables.Add(subscription);
     }

--- a/src/Zafiro/Username.cs
+++ b/src/Zafiro/Username.cs
@@ -31,6 +31,6 @@ public class Username : ValueObject, IComparable
 
     public int CompareTo(object? obj)
     {
-        return Identifier.CompareTo(obj);   
+        return Identifier.CompareTo(obj);
     }
 }

--- a/src/Zafiro/Values/GroupGetter.cs
+++ b/src/Zafiro/Values/GroupGetter.cs
@@ -18,8 +18,8 @@ public class GroupGetter
     public object GetValue(IEnumerable<object> targets)
     {
         var query = from target in targets
-            from prop in target.GetType().GetRuntimeProperties().Where(x => string.Equals(x.Name, property.Name))
-            select new { target, prop };
+                    from prop in target.GetType().GetRuntimeProperties().Where(x => string.Equals(x.Name, property.Name))
+                    select new { target, prop };
 
         var values = query.Select(x =>
         {


### PR DESCRIPTION
Summary\n- Apply formatting-only changes (whitespace/spacing) across multiple files under Zafiro.*.\n- No functional changes: trim trailing spaces, align spacing, normalize blank lines.\n\nVerification\n- Built Zafiro.sln successfully on Linux (Pop!_OS) with .NET SDK, all projects compiled.\n\nRationale\n- Keep the codebase consistent and avoid noisy diffs when tooling auto-formats files.\n