### PR TITLE
fix: accumulate section factories instead of overwriting

### DIFF
--- a/src/Zafiro.UI/Navigation/NavigationServiceCollectionExtensions.cs
+++ b/src/Zafiro.UI/Navigation/NavigationServiceCollectionExtensions.cs
@@ -11,7 +11,11 @@ public static class NavigationServiceCollectionExtensions
 {
     public static IServiceCollection AddSections(this IServiceCollection serviceCollection, Func<IServiceProvider, IEnumerable<ISection>> factory, ILogger? logger = null, IScheduler? scheduler = null)
     {
-        serviceCollection.AddSingleton(factory);
+        serviceCollection.AddSingleton(new SectionFactory(factory));
+        serviceCollection.TryAddSingleton<IEnumerable<ISection>>(sp =>
+            sp.GetServices<SectionFactory>()
+              .SelectMany(f => f.Create(sp))
+              .ToList());
         EnsureNavigatorRegistration(serviceCollection, logger, scheduler);
         return serviceCollection;
     }

--- a/src/Zafiro.UI/Navigation/SectionFactory.cs
+++ b/src/Zafiro.UI/Navigation/SectionFactory.cs
@@ -1,0 +1,8 @@
+using Zafiro.UI.Navigation.Sections;
+
+namespace Zafiro.UI.Navigation;
+
+internal sealed class SectionFactory(Func<IServiceProvider, IEnumerable<ISection>> factory)
+{
+    public IEnumerable<ISection> Create(IServiceProvider provider) => factory(provider);
+}

--- a/test/Zafiro.Tests/UI/AddSectionsTests.cs
+++ b/test/Zafiro.Tests/UI/AddSectionsTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Zafiro.UI.Navigation;
+using Zafiro.UI.Navigation.Sections;
+
+namespace Zafiro.Tests.UI;
+
+public class AddSectionsTests
+{
+    [Fact]
+    public void Multiple_AddSections_calls_accumulate_sections()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSections(builder =>
+        {
+            builder.AddSection<DummyViewModelA>("A", "Section A");
+        });
+
+        services.AddSections(builder =>
+        {
+            builder.AddSection<DummyViewModelB>("B", "Section B");
+        });
+
+        var provider = services.BuildServiceProvider();
+        var sections = provider.GetRequiredService<IEnumerable<ISection>>().ToList();
+
+        sections.Select(s => s.Id).Should().BeEquivalentTo(new[] { "A", "B" });
+    }
+
+    [Fact]
+    public void Single_AddSections_call_registers_all_sections()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSections(builder =>
+        {
+            builder.AddSection<DummyViewModelA>("X", "Section X");
+            builder.AddSection<DummyViewModelB>("Y", "Section Y");
+        });
+
+        var provider = services.BuildServiceProvider();
+        var sections = provider.GetRequiredService<IEnumerable<ISection>>().ToList();
+
+        sections.Select(s => s.Id).Should().BeEquivalentTo(new[] { "X", "Y" });
+    }
+
+    [Fact]
+    public void Empty_AddSections_call_does_not_wipe_previous_sections()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSections(builder =>
+        {
+            builder.AddSection<DummyViewModelA>("Real", "Real Section");
+        });
+
+        // Simulate an assembly with no sections (empty builder)
+        services.AddSections(_ => { });
+
+        var provider = services.BuildServiceProvider();
+        var sections = provider.GetRequiredService<IEnumerable<ISection>>().ToList();
+
+        sections.Should().ContainSingle(s => s.Id == "Real");
+    }
+
+    private class DummyViewModelA;
+    private class DummyViewModelB;
+}


### PR DESCRIPTION
## Problem

`AddSections()` used `AddSingleton(factory)` to register `IEnumerable<ISection>`. When called multiple times (e.g. by source-generated module initializers from different assemblies), the **last registration wins**. Which one is "last" depends on `Dictionary` iteration order in `SectionRegistrationRegistry`, which differs between CoreCLR (desktop) and MonoVM (Android).

This causes a non-deterministic `KeyNotFoundException` crash on Android — the app works on desktop purely by luck of hash ordering.

## Root Cause

`SectionRegistrationRegistry` stores registrations in a `Dictionary<string, Registration>`. When `AddAllSectionsFromRegistry` iterates `dictionary.Values` and calls `AddSections()` for each assembly, the last `AddSingleton(factory)` call overwrites previous ones. On Android (MonoVM), an empty assembly's factory happened to be last, wiping all real sections.

## Fix

- Register each section factory as a `SectionFactory` wrapper instance (`AddSingleton(new SectionFactory(factory))`) — MS DI collects all via `GetServices<SectionFactory>()`
- Use `TryAddSingleton<IEnumerable<ISection>>` with a combined resolver that calls `SelectMany` over all factories
- This ensures multiple `AddSections()` calls **accumulate** rather than overwrite

## Tests

3 new tests in `AddSectionsTests`:
- `Multiple_AddSections_calls_accumulate_sections` — the core bug scenario
- `Single_AddSections_call_registers_all_sections` — basic sanity
- `Empty_AddSections_call_does_not_wipe_previous_sections` — simulates an assembly with no sections

All 117 tests pass (114 existing + 3 new).