### PR TITLE
fix(shell): restore deterministic initial section + remove RxApp usage

### DIFF
--- a/src/Zafiro.UI/Navigation/NavigationServiceCollectionExtensions.cs
+++ b/src/Zafiro.UI/Navigation/NavigationServiceCollectionExtensions.cs
@@ -67,6 +67,6 @@ public static class NavigationServiceCollectionExtensions
 
     private static void EnsureNavigatorRegistration(IServiceCollection services, ILogger? logger, IScheduler? scheduler)
     {
-        services.TryAddScoped<INavigator>(sp => new Navigator(sp, logger.AsMaybe(), scheduler ?? RxApp.MainThreadScheduler));
+        services.TryAddScoped<INavigator>(sp => new Navigator(sp, logger.AsMaybe(), scheduler ?? RxSchedulers.MainThreadScheduler));
     }
 }

--- a/src/Zafiro.UI/Shell/Shell.cs
+++ b/src/Zafiro.UI/Shell/Shell.cs
@@ -9,7 +9,11 @@ public class Shell : IShell, IDisposable
     public Shell(IEnumerable<ISection> sections, IServiceProvider provider)
     {
         Sections = sections;
-        SelectedSection = new global::Reactive.Bindings.ReactiveProperty<ISection>(Sections.FirstOrDefault());
+        var initial = Sections
+            .Where(s => s.IsVisible)
+            .OrderBy(s => s.SortOrder)
+            .FirstOrDefault();
+        SelectedSection = new global::Reactive.Bindings.ReactiveProperty<ISection>(initial);
     }
 
     public void Dispose()

--- a/src/Zafiro.UI/Shell/ShellServiceCollectionExtensions.cs
+++ b/src/Zafiro.UI/Shell/ShellServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ public static class ShellServiceCollectionExtensions
     {
         services.AddSingleton<IShell, Shell>();
         services.TryAddScoped<INavigator>(sp =>
-            new Navigator(sp, logger.AsMaybe(), RxApp.MainThreadScheduler));
+            new Navigator(sp, logger.AsMaybe(), RxSchedulers.MainThreadScheduler));
 
         return services;
     }

--- a/src/Zafiro.UI/Wizards/Slim/SlimWizard.cs
+++ b/src/Zafiro.UI/Wizards/Slim/SlimWizard.cs
@@ -47,7 +47,7 @@ public sealed class SlimWizard<TResult> : ReactiveObject, ISlimWizard<TResult>, 
     {
         EnsureValidSteps(steps);
         this.steps = steps;
-        this.scheduler = scheduler ?? RxApp.MainThreadScheduler;
+        this.scheduler = scheduler ?? RxSchedulers.MainThreadScheduler;
         TotalPages = steps.Count;
 
         pageInstances = new object?[TotalPages];

--- a/src/Zafiro/Reactive/ObservableMixin.cs
+++ b/src/Zafiro/Reactive/ObservableMixin.cs
@@ -147,7 +147,7 @@ public static class ObservableMixin
         IScheduler scheduler = null)
     {
         strategy ??= ExponentialBackoff;
-        scheduler ??= RxApp.TaskpoolScheduler;
+        scheduler ??= RxSchedulers.TaskpoolScheduler;
 
         if (retryOnError == null)
         {


### PR DESCRIPTION
Fixes the runtime side of [SuperJMN/Zafiro.Avalonia#232](https://github.com/SuperJMN/Zafiro.Avalonia/issues/232) (empty `Frame` in `ShellView`).

## Root cause

ReactiveUI 23 removed the public `RxApp` class — it was replaced by `RxSchedulers`, which is also available in 22.x. Zafiro.UI still referenced `RxApp.MainThreadScheduler` / `RxApp.TaskpoolScheduler` in four places. The moment a consumer restored Zafiro.UI alongside ReactiveUI 23 (as Zafiro.Avalonia does), the JIT threw `TypeLoadException` the first time the binding chain triggered the `Navigator` lazy in `Section.Navigator`. Avalonia's binding engine swallowed the exception, so the shell `Frame.Content` ended up silently unset — exactly the symptom reported in the issue.

## Changes

- Replace `RxApp.MainThreadScheduler` / `RxApp.TaskpoolScheduler` with `RxSchedulers.*` in:
  - `ShellServiceCollectionExtensions.cs`
  - `NavigationServiceCollectionExtensions.cs`
  - `Wizards/Slim/SlimWizard.cs`
  - `Reactive/ObservableMixin.cs`
  Both APIs exist in ReactiveUI 22.2.1 and 23.1.x, so this is binary-compatible across both major versions.
- `Shell.cs`: order visible sections by `SortOrder` before picking the initial one, so the auto-selected section matches the sidebar's display order instead of arbitrary container iteration order.

## Validation

Built locally and verified end-to-end against `MinimalShell` from Zafiro.Avalonia (with the matching `SectionStrip.axaml` two-way fix in that repo): the Frame now shows the Home view on startup, and clicking sidebar items swaps content correctly.