### PR TITLE
Add hierarchical shell sections

### DIFF
--- a/src/Zafiro.UI/Navigation/NavigationServiceCollectionExtensions.cs
+++ b/src/Zafiro.UI/Navigation/NavigationServiceCollectionExtensions.cs
@@ -32,9 +32,28 @@ public static class NavigationServiceCollectionExtensions
 
     public static IServiceCollection AddSectionsFromAttributes(this IServiceCollection serviceCollection, Assembly assembly, ILogger? logger = null, IScheduler? scheduler = null)
     {
+        return serviceCollection.AddSectionsFromAttributes(assembly, _ => true, logger, scheduler);
+    }
+
+    public static IServiceCollection AddSectionsFromAttributes(this IServiceCollection serviceCollection, Assembly assembly, Func<Type, bool> predicate, ILogger? logger = null, IScheduler? scheduler = null)
+    {
+        var sectionTypes = assembly.GetTypes()
+            .Where(Extensions.IsSection)
+            .Where(predicate)
+            .ToList();
+
+        foreach (var type in sectionTypes)
+        {
+            var sectionAttr = type.GetCustomAttribute<SectionAttribute>();
+            if (sectionAttr is not null)
+            {
+                RegisterSectionViewModel(serviceCollection, type, sectionAttr);
+            }
+        }
+
         return serviceCollection.AddSections(builder =>
         {
-            foreach (var type in assembly.GetTypes().Where(Extensions.IsSection))
+            foreach (var type in sectionTypes)
             {
                 var sectionAttr = type.GetCustomAttribute<SectionAttribute>();
                 if (sectionAttr is null)
@@ -51,6 +70,8 @@ public static class NavigationServiceCollectionExtensions
                 var contractType = sectionAttr.ContractType ?? type;
                 var name = sectionAttr.Name ?? displayName;
                 var iconSource = sectionAttr.Icon ?? "fa-window-maximize";
+                var parentId = sectionAttr.ParentId;
+                var shortName = sectionAttr.ShortName;
 
                 var groupAttr = type.GetCustomAttribute<SectionGroupAttribute>();
                 SectionGroup? group = null;
@@ -59,10 +80,32 @@ public static class NavigationServiceCollectionExtensions
                     group = new SectionGroup(groupAttr.FriendlyName ?? groupAttr.Key);
                 }
 
-                var method = typeof(SectionsBuilder).GetMethod(nameof(SectionsBuilder.AddSection))!.MakeGenericMethod(contractType);
-                method.Invoke(builder, new object?[] { name, friendlyName, new Icon { Source = iconSource }, group, sectionAttr.SortIndex });
+                var method = typeof(SectionsBuilder).GetMethod(nameof(SectionsBuilder.AddSection),
+                    [
+                        typeof(string),
+                        typeof(string),
+                        typeof(object),
+                        typeof(SectionGroup),
+                        typeof(int),
+                        typeof(string),
+                        typeof(string)
+                    ])!.MakeGenericMethod(contractType);
+                method.Invoke(builder, new object?[] { name, friendlyName, new Icon { Source = iconSource }, group, sectionAttr.SortIndex, shortName, parentId });
             }
         }, logger, scheduler);
+    }
+
+    private static void RegisterSectionViewModel(IServiceCollection services, Type implementationType, SectionAttribute sectionAttribute)
+    {
+        var contractType = sectionAttribute.ContractType ?? implementationType;
+
+        if (contractType == implementationType)
+        {
+            services.TryAddTransient(implementationType);
+            return;
+        }
+
+        services.TryAddTransient(contractType, implementationType);
     }
 
     private static void EnsureNavigatorRegistration(IServiceCollection services, ILogger? logger, IScheduler? scheduler)

--- a/src/Zafiro.UI/Navigation/Sections/IHierarchicalSection.cs
+++ b/src/Zafiro.UI/Navigation/Sections/IHierarchicalSection.cs
@@ -1,0 +1,6 @@
+namespace Zafiro.UI.Navigation.Sections;
+
+public interface IHierarchicalSection : ISection
+{
+    string? ParentId { get; }
+}

--- a/src/Zafiro.UI/Navigation/Sections/ISection.cs
+++ b/src/Zafiro.UI/Navigation/Sections/ISection.cs
@@ -7,7 +7,6 @@ public interface ISection : INotifyPropertyChanged, IDisposable
     bool IsVisible { get; set; }
     int SortOrder { get; set; }
     string Id { get; }
-    string? ParentId { get; }
     public string? ShortName { get; }
     string FriendlyName { get; }
     SectionGroup Group { get; }

--- a/src/Zafiro.UI/Navigation/Sections/ISection.cs
+++ b/src/Zafiro.UI/Navigation/Sections/ISection.cs
@@ -7,6 +7,7 @@ public interface ISection : INotifyPropertyChanged, IDisposable
     bool IsVisible { get; set; }
     int SortOrder { get; set; }
     string Id { get; }
+    string? ParentId { get; }
     public string? ShortName { get; }
     string FriendlyName { get; }
     SectionGroup Group { get; }

--- a/src/Zafiro.UI/Navigation/Sections/Section.cs
+++ b/src/Zafiro.UI/Navigation/Sections/Section.cs
@@ -3,7 +3,7 @@ using ReactiveUI.SourceGenerators;
 
 namespace Zafiro.UI.Navigation.Sections;
 
-public partial class Section : ReactiveObject, ISection
+public partial class Section : ReactiveObject, IHierarchicalSection
 {
     private readonly Lazy<INavigator> navigatorLazy;
     private readonly IServiceScope sectionScope;

--- a/src/Zafiro.UI/Navigation/Sections/Section.cs
+++ b/src/Zafiro.UI/Navigation/Sections/Section.cs
@@ -11,9 +11,10 @@ public partial class Section : ReactiveObject, ISection
     [Reactive] private int sortOrder;
     private string? shortName;
 
-    public Section(string name, IServiceProvider provider, Type initialContentType, object? icon = null, SectionGroup? group = null, string? friendlyName = null)
+    public Section(string name, IServiceProvider provider, Type initialContentType, object? icon = null, SectionGroup? group = null, string? friendlyName = null, string? parentId = null)
     {
         Id = name;
+        ParentId = parentId;
         FriendlyName = friendlyName ?? name;
         Group = group ?? new SectionGroup();
         Icon = icon;
@@ -28,6 +29,7 @@ public partial class Section : ReactiveObject, ISection
     }
 
     public string Id { get; }
+    public string? ParentId { get; }
     public string? ShortName
     {
         get => string.IsNullOrWhiteSpace(shortName)

--- a/src/Zafiro.UI/Navigation/SectionsBuilder.cs
+++ b/src/Zafiro.UI/Navigation/SectionsBuilder.cs
@@ -12,9 +12,14 @@ public class SectionsBuilder
     /// </summary>
     public SectionsBuilder AddSection<T>(string name, string friendlyName, object? icon = null, SectionGroup? group = null, int sortOrder = 0, string? shortName = null) where T : class
     {
+        return AddSection<T>(name, friendlyName, icon, group, sortOrder, shortName, null);
+    }
+
+    public SectionsBuilder AddSection<T>(string name, string friendlyName, object? icon, SectionGroup? group, int sortOrder, string? shortName, string? parentId) where T : class
+    {
         sectionFactories.Add((provider, scheduler, logger) =>
         {
-            var root = new Section(name, provider, typeof(T), icon, group, friendlyName)
+            var root = new Section(name, provider, typeof(T), icon, group, friendlyName, parentId)
             {
                 SortOrder = sortOrder,
                 ShortName = shortName
@@ -23,8 +28,6 @@ public class SectionsBuilder
         });
         return this;
     }
-
-    // Backwards-compat overload: ignore isPrimary
 
     public IEnumerable<ISection> Build(IServiceProvider provider, IScheduler? scheduler = null, Maybe<ILogger> logger = default)
     {

--- a/src/Zafiro.UI/Shell/IHierarchicalShell.cs
+++ b/src/Zafiro.UI/Shell/IHierarchicalShell.cs
@@ -1,0 +1,10 @@
+using Zafiro.UI.Navigation.Sections;
+
+namespace Zafiro.UI.Shell;
+
+public interface IHierarchicalShell : IShell
+{
+    SectionLevel RootLevel { get; }
+    global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<SectionLevel>> ChildLevels { get; }
+    global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<ISection>> SelectedPath { get; }
+}

--- a/src/Zafiro.UI/Shell/IShell.cs
+++ b/src/Zafiro.UI/Shell/IShell.cs
@@ -5,9 +5,6 @@ namespace Zafiro.UI.Shell;
 public interface IShell
 {
     IEnumerable<ISection> Sections { get; }
-    SectionLevel RootLevel { get; }
-    global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<SectionLevel>> ChildLevels { get; }
     global::Reactive.Bindings.ReactiveProperty<ISection> SelectedSection { get; }
-    global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<ISection>> SelectedPath { get; }
     void GoToSection(string sectionId);
 }

--- a/src/Zafiro.UI/Shell/IShell.cs
+++ b/src/Zafiro.UI/Shell/IShell.cs
@@ -5,6 +5,9 @@ namespace Zafiro.UI.Shell;
 public interface IShell
 {
     IEnumerable<ISection> Sections { get; }
+    SectionLevel RootLevel { get; }
+    global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<SectionLevel>> ChildLevels { get; }
     global::Reactive.Bindings.ReactiveProperty<ISection> SelectedSection { get; }
+    global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<ISection>> SelectedPath { get; }
     void GoToSection(string sectionId);
 }

--- a/src/Zafiro.UI/Shell/SectionLevel.cs
+++ b/src/Zafiro.UI/Shell/SectionLevel.cs
@@ -1,0 +1,42 @@
+using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
+using Zafiro.UI.Navigation.Sections;
+
+namespace Zafiro.UI.Shell;
+
+public sealed class SectionLevel : IDisposable
+{
+    private readonly CompositeDisposable disposable = new();
+    private readonly Action<ISection> selectSection;
+    private bool isUpdatingSelection;
+
+    public SectionLevel(IEnumerable<ISection> sections, ISection selectedSection, Action<ISection> selectSection)
+    {
+        Sections = sections.ToList();
+        SelectedSection = new global::Reactive.Bindings.ReactiveProperty<ISection>(selectedSection).DisposeWith(disposable);
+        this.selectSection = selectSection;
+
+        SelectedSection
+            .Skip(1)
+            .Where(_ => !isUpdatingSelection)
+            .Do(this.selectSection)
+            .Subscribe()
+            .DisposeWith(disposable);
+    }
+
+    public IReadOnlyList<ISection> Sections { get; }
+
+    public global::Reactive.Bindings.ReactiveProperty<ISection> SelectedSection { get; }
+
+    internal void SetSelectedSection(ISection selectedSection)
+    {
+        isUpdatingSelection = true;
+        SelectedSection.Value = selectedSection;
+        isUpdatingSelection = false;
+    }
+
+    public void Dispose()
+    {
+        disposable.Dispose();
+    }
+}

--- a/src/Zafiro.UI/Shell/Shell.cs
+++ b/src/Zafiro.UI/Shell/Shell.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System.Reactive.Disposables;
+using JetBrains.Annotations;
 using Zafiro.UI.Navigation.Sections;
 
 namespace Zafiro.UI.Shell;
@@ -6,18 +7,43 @@ namespace Zafiro.UI.Shell;
 [PublicAPI]
 public class Shell : IShell, IDisposable
 {
+    private readonly Dictionary<string, ISection> sectionsById;
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<ISection>> childrenByParentId;
+    private readonly Dictionary<string, string> selectedChildByParentId = new();
+    private IReadOnlyList<SectionLevel> childLevels = [];
+
     public Shell(IEnumerable<ISection> sections, IServiceProvider provider)
     {
-        Sections = sections;
-        var initial = Sections
-            .Where(s => s.IsVisible)
-            .OrderBy(s => s.SortOrder)
-            .FirstOrDefault();
-        SelectedSection = new global::Reactive.Bindings.ReactiveProperty<ISection>(initial);
+        Sections = sections.ToList();
+        sectionsById = Sections.ToDictionary(section => section.Id);
+        childrenByParentId = Sections
+            .Where(section => !string.IsNullOrWhiteSpace(section.ParentId))
+            .GroupBy(section => section.ParentId!)
+            .ToDictionary(group => group.Key, group => Sort(group).ToList() as IReadOnlyList<ISection>);
+
+        var rootSections = Sort(Sections.Where(section => string.IsNullOrWhiteSpace(section.ParentId))).ToList();
+        var initialRoot = rootSections.FirstOrDefault(section => section.IsVisible);
+        var initialSection = initialRoot is null ? null : ResolveSelectedSection(initialRoot);
+
+        SelectedSection = new global::Reactive.Bindings.ReactiveProperty<ISection>(initialSection!);
+        SelectedPath = new global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<ISection>>(initialSection is null ? [] : BuildPath(initialSection));
+        ChildLevels = new global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<SectionLevel>>([]);
+        RootLevel = new SectionLevel(rootSections, initialRoot!, SelectSection);
+
+        if (initialSection is not null)
+        {
+            UpdateSelectedSection(initialSection);
+        }
     }
 
     public void Dispose()
     {
+        RootLevel.Dispose();
+        DisposeChildLevels();
+        SelectedSection.Dispose();
+        SelectedPath.Dispose();
+        ChildLevels.Dispose();
+
         foreach (var section in Sections)
         {
             section.Dispose();
@@ -25,10 +51,112 @@ public class Shell : IShell, IDisposable
     }
 
     public IEnumerable<ISection> Sections { get; }
+    public SectionLevel RootLevel { get; }
+    public global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<SectionLevel>> ChildLevels { get; }
     public global::Reactive.Bindings.ReactiveProperty<ISection> SelectedSection { get; }
+    public global::Reactive.Bindings.ReactiveProperty<IReadOnlyList<ISection>> SelectedPath { get; }
 
     public void GoToSection(string sectionId)
     {
-        SelectedSection.Value = Sections.First(x => x.Id == sectionId);
+        SelectSection(sectionsById[sectionId]);
+    }
+
+    private static IEnumerable<ISection> Sort(IEnumerable<ISection> sections)
+    {
+        return sections
+            .OrderBy(section => section.SortOrder);
+    }
+
+    private IReadOnlyList<ISection> GetChildren(ISection parent)
+    {
+        return childrenByParentId.TryGetValue(parent.Id, out var children)
+            ? Sort(children).ToList()
+            : [];
+    }
+
+    private ISection ResolveSelectedSection(ISection section)
+    {
+        var children = GetChildren(section)
+            .Where(child => child.IsVisible)
+            .ToList();
+        if (children.Count is 0)
+        {
+            return section;
+        }
+
+        var rememberedChild = selectedChildByParentId.TryGetValue(section.Id, out var childId)
+            && sectionsById.TryGetValue(childId, out var child)
+            && children.Contains(child)
+                ? child
+                : children[0];
+
+        return ResolveSelectedSection(rememberedChild);
+    }
+
+    private void SelectSection(ISection section)
+    {
+        UpdateSelectedSection(ResolveSelectedSection(section));
+    }
+
+    private void UpdateSelectedSection(ISection section)
+    {
+        var path = BuildPath(section);
+        RememberSelectedChildren(path);
+
+        SelectedSection.Value = section;
+        SelectedPath.Value = path;
+        RootLevel.SetSelectedSection(path[0]);
+        ReplaceChildLevels(CreateChildLevels(path));
+    }
+
+    private IReadOnlyList<ISection> BuildPath(ISection section)
+    {
+        var path = new Stack<ISection>();
+        var current = section;
+
+        while (true)
+        {
+            path.Push(current);
+
+            if (string.IsNullOrWhiteSpace(current.ParentId) || !sectionsById.TryGetValue(current.ParentId, out var parent))
+            {
+                break;
+            }
+
+            current = parent;
+        }
+
+        return path.ToList();
+    }
+
+    private void RememberSelectedChildren(IReadOnlyList<ISection> path)
+    {
+        foreach (var pair in path.Zip(path.Skip(1)))
+        {
+            selectedChildByParentId[pair.First.Id] = pair.Second.Id;
+        }
+    }
+
+    private IReadOnlyList<SectionLevel> CreateChildLevels(IReadOnlyList<ISection> path)
+    {
+        return path
+            .Take(path.Count - 1)
+            .Select((section, index) => new SectionLevel(GetChildren(section), path[index + 1], SelectSection))
+            .ToList();
+    }
+
+    private void ReplaceChildLevels(IReadOnlyList<SectionLevel> levels)
+    {
+        DisposeChildLevels();
+        childLevels = levels;
+        ChildLevels.Value = childLevels;
+    }
+
+    private void DisposeChildLevels()
+    {
+        foreach (var level in childLevels)
+        {
+            level.Dispose();
+        }
     }
 }

--- a/src/Zafiro.UI/Shell/Shell.cs
+++ b/src/Zafiro.UI/Shell/Shell.cs
@@ -5,7 +5,7 @@ using Zafiro.UI.Navigation.Sections;
 namespace Zafiro.UI.Shell;
 
 [PublicAPI]
-public class Shell : IShell, IDisposable
+public class Shell : IHierarchicalShell, IDisposable
 {
     private readonly Dictionary<string, ISection> sectionsById;
     private readonly IReadOnlyDictionary<string, IReadOnlyList<ISection>> childrenByParentId;
@@ -17,11 +17,11 @@ public class Shell : IShell, IDisposable
         Sections = sections.ToList();
         sectionsById = Sections.ToDictionary(section => section.Id);
         childrenByParentId = Sections
-            .Where(section => !string.IsNullOrWhiteSpace(section.ParentId))
-            .GroupBy(section => section.ParentId!)
+            .Where(section => !string.IsNullOrWhiteSpace(GetParentId(section)))
+            .GroupBy(section => GetParentId(section)!)
             .ToDictionary(group => group.Key, group => Sort(group).ToList() as IReadOnlyList<ISection>);
 
-        var rootSections = Sort(Sections.Where(section => string.IsNullOrWhiteSpace(section.ParentId))).ToList();
+        var rootSections = Sort(Sections.Where(section => string.IsNullOrWhiteSpace(GetParentId(section)))).ToList();
         var initialRoot = rootSections.FirstOrDefault(section => section.IsVisible);
         var initialSection = initialRoot is null ? null : ResolveSelectedSection(initialRoot);
 
@@ -118,7 +118,8 @@ public class Shell : IShell, IDisposable
         {
             path.Push(current);
 
-            if (string.IsNullOrWhiteSpace(current.ParentId) || !sectionsById.TryGetValue(current.ParentId, out var parent))
+            var parentId = GetParentId(current);
+            if (string.IsNullOrWhiteSpace(parentId) || !sectionsById.TryGetValue(parentId, out var parent))
             {
                 break;
             }
@@ -158,5 +159,10 @@ public class Shell : IShell, IDisposable
         {
             level.Dispose();
         }
+    }
+
+    private static string? GetParentId(ISection section)
+    {
+        return section is IHierarchicalSection hierarchicalSection ? hierarchicalSection.ParentId : null;
     }
 }

--- a/src/Zafiro.UI/Shell/ShellServiceCollectionExtensions.cs
+++ b/src/Zafiro.UI/Shell/ShellServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ public static class ShellServiceCollectionExtensions
     /// <summary>
     /// Registers the complete Zafiro Shell infrastructure:
     /// <list type="bullet">
-    ///     <item><see cref="IShell"/> → <see cref="Shell"/></item>
+    ///     <item><see cref="IShell"/> and <see cref="IHierarchicalShell"/> → <see cref="Shell"/></item>
     ///     <item><see cref="INavigator"/> (scoped, one per section)</item>
     /// </list>
     /// After calling this method, the consumer only needs to call <c>services.AddAllSectionsFromAttributes()</c>
@@ -25,7 +25,9 @@ public static class ShellServiceCollectionExtensions
         this IServiceCollection services,
         ILogger? logger = null)
     {
-        services.AddSingleton<IShell, Shell>();
+        services.AddSingleton<Shell>();
+        services.AddSingleton<IShell>(provider => provider.GetRequiredService<Shell>());
+        services.AddSingleton<IHierarchicalShell>(provider => provider.GetRequiredService<Shell>());
         services.TryAddScoped<INavigator>(sp =>
             new Navigator(sp, logger.AsMaybe(), RxSchedulers.MainThreadScheduler));
 

--- a/src/Zafiro.UI/Shell/Utils/SectionAttribute.cs
+++ b/src/Zafiro.UI/Shell/Utils/SectionAttribute.cs
@@ -18,6 +18,11 @@ public class SectionAttribute(string? name = null, string? icon = null, int sort
     /// </summary>
     public string? ShortName { get; set; }
 
+    /// <summary>
+    /// Optional parent section id. Sections without a parent id are root sections.
+    /// </summary>
+    public string? ParentId { get; set; }
+
     public string? Icon { get; } = icon;
     public int SortIndex { get; } = sortIndex;
 

--- a/test/Zafiro.Tests/UI/AddSectionsTests.cs
+++ b/test/Zafiro.Tests/UI/AddSectionsTests.cs
@@ -87,7 +87,9 @@ public class AddSectionsTests
         var provider = services.BuildServiceProvider();
         var sections = provider.GetRequiredService<IEnumerable<ISection>>().ToList();
 
-        sections.Should().ContainSingle(s => s.Id == "Child" && s.ParentId == "Parent");
+        sections.Should().ContainSingle(s => s.Id == "Child")
+            .Which.Should().BeAssignableTo<IHierarchicalSection>()
+            .Which.ParentId.Should().Be("Parent");
     }
 
     private class DummyViewModelA;

--- a/test/Zafiro.Tests/UI/AddSectionsTests.cs
+++ b/test/Zafiro.Tests/UI/AddSectionsTests.cs
@@ -65,6 +65,31 @@ public class AddSectionsTests
         sections.Should().ContainSingle(s => s.Id == "Real");
     }
 
+    [Fact]
+    public void SectionsBuilder_preserves_the_original_AddSection_binary_signature()
+    {
+        var method = typeof(SectionsBuilder).GetMethod(nameof(SectionsBuilder.AddSection),
+            new[] { typeof(string), typeof(string), typeof(object), typeof(SectionGroup), typeof(int), typeof(string) });
+
+        method.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddSection_can_assign_parent_id_when_all_hierarchy_arguments_are_provided()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSections(builder =>
+        {
+            builder.AddSection<DummyViewModelA>("Child", "Child", null, null, 0, null, "Parent");
+        });
+
+        var provider = services.BuildServiceProvider();
+        var sections = provider.GetRequiredService<IEnumerable<ISection>>().ToList();
+
+        sections.Should().ContainSingle(s => s.Id == "Child" && s.ParentId == "Parent");
+    }
+
     private class DummyViewModelA;
     private class DummyViewModelB;
 }

--- a/test/Zafiro.Tests/UI/AttributeShellRegistrationTests.cs
+++ b/test/Zafiro.Tests/UI/AttributeShellRegistrationTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Zafiro.UI.Navigation;
+using Zafiro.UI.Shell;
+using Zafiro.UI.Shell.Utils;
+
+namespace Zafiro.Tests.UI;
+
+public class AttributeShellRegistrationTests
+{
+    [Fact]
+    public async Task Filtered_attribute_registration_creates_hierarchical_sections_with_scoped_navigation()
+    {
+        var services = new ServiceCollection();
+        services.AddZafiroShell();
+        services.AddTransient<ActiveUsersDetailsViewModel>();
+        services.AddSectionsFromAttributes(typeof(AttributeShellRegistrationTests).Assembly, IsDemoSection);
+
+        using var provider = services.BuildServiceProvider();
+        using var shell = (Shell)provider.GetRequiredService<IShell>();
+
+        shell.RootLevel.Sections.Select(section => section.Id).Should().Equal("workspace");
+        shell.SelectedPath.Value.Select(section => section.Id).Should().Equal("workspace", "users", "active-users");
+        shell.ChildLevels.Value.Should().HaveCount(2);
+        shell.ChildLevels.Value[0].Sections.Select(section => section.Id).Should().Equal("users", "security");
+        shell.ChildLevels.Value[1].Sections.Select(section => section.Id).Should().Equal("active-users", "user-roles");
+
+        var activeUsersNavigator = shell.SelectedSection.Value.Navigator;
+        await activeUsersNavigator.Go(typeof(ActiveUsersDetailsViewModel));
+
+        shell.GoToSection("security");
+        var securityContent = await shell.SelectedSection.Value.Navigator.Content.FirstAsync();
+        securityContent.Should().BeOfType<SecurityViewModel>();
+
+        shell.GoToSection("active-users");
+        var activeUsersContent = await shell.SelectedSection.Value.Navigator.Content.FirstAsync();
+        activeUsersContent.Should().BeOfType<ActiveUsersDetailsViewModel>();
+    }
+
+    private static bool IsDemoSection(Type type)
+    {
+        return type.DeclaringType == typeof(AttributeShellRegistrationTests);
+    }
+
+    [Section("workspace", "mdi-view-dashboard", 0)]
+    public class WorkspaceViewModel;
+
+    [Section("users", "mdi-account-group", 0, ParentId = "workspace")]
+    public class UsersViewModel;
+
+    [Section("security", "mdi-shield-key", 1, ParentId = "workspace")]
+    public class SecurityViewModel;
+
+    [Section("active-users", "mdi-account-check", 0, ParentId = "users")]
+    public class ActiveUsersViewModel;
+
+    [Section("user-roles", "mdi-account-key", 1, ParentId = "users")]
+    public class UserRolesViewModel;
+
+    public class ActiveUsersDetailsViewModel;
+}

--- a/test/Zafiro.Tests/UI/AttributeShellRegistrationTests.cs
+++ b/test/Zafiro.Tests/UI/AttributeShellRegistrationTests.cs
@@ -20,7 +20,7 @@ public class AttributeShellRegistrationTests
         services.AddSectionsFromAttributes(typeof(AttributeShellRegistrationTests).Assembly, IsDemoSection);
 
         using var provider = services.BuildServiceProvider();
-        using var shell = (Shell)provider.GetRequiredService<IShell>();
+        using var shell = (Shell)provider.GetRequiredService<IHierarchicalShell>();
 
         shell.RootLevel.Sections.Select(section => section.Id).Should().Equal("workspace");
         shell.SelectedPath.Value.Select(section => section.Id).Should().Equal("workspace", "users", "active-users");

--- a/test/Zafiro.Tests/UI/ShellHierarchyTests.cs
+++ b/test/Zafiro.Tests/UI/ShellHierarchyTests.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Zafiro.UI.Navigation.Sections;
+using Zafiro.UI.Shell;
+
+namespace Zafiro.Tests.UI;
+
+public class ShellHierarchyTests
+{
+    [Fact]
+    public void Initial_selection_uses_first_visible_descendant_of_first_root()
+    {
+        using var provider = new ServiceCollection().BuildServiceProvider();
+        using var shell = new Shell([
+            CreateSection(provider, "admin", sortOrder: 0),
+            CreateSection(provider, "reports", sortOrder: 1),
+            CreateSection(provider, "roles", parentId: "admin", sortOrder: 1),
+            CreateSection(provider, "users", parentId: "admin", sortOrder: 0),
+        ], provider);
+
+        shell.RootLevel.Sections.Select(section => section.Id).Should().Equal("admin", "reports");
+        shell.RootLevel.SelectedSection.Value.Id.Should().Be("admin");
+        shell.SelectedSection.Value.Id.Should().Be("users");
+        shell.SelectedPath.Value.Select(section => section.Id).Should().Equal("admin", "users");
+        shell.ChildLevels.Value.Should().ContainSingle();
+        shell.ChildLevels.Value[0].Sections.Select(section => section.Id).Should().Equal("users", "roles");
+        shell.ChildLevels.Value[0].SelectedSection.Value.Id.Should().Be("users");
+    }
+
+    [Fact]
+    public void Selecting_a_root_restores_the_last_selected_descendant_for_that_branch()
+    {
+        using var provider = new ServiceCollection().BuildServiceProvider();
+        using var shell = new Shell([
+            CreateSection(provider, "admin", sortOrder: 0),
+            CreateSection(provider, "reports", sortOrder: 1),
+            CreateSection(provider, "users", parentId: "admin", sortOrder: 0),
+            CreateSection(provider, "roles", parentId: "admin", sortOrder: 1),
+            CreateSection(provider, "sales", parentId: "reports", sortOrder: 0),
+        ], provider);
+
+        shell.GoToSection("roles");
+        shell.GoToSection("sales");
+        shell.GoToSection("admin");
+
+        shell.RootLevel.SelectedSection.Value.Id.Should().Be("admin");
+        shell.SelectedSection.Value.Id.Should().Be("roles");
+        shell.SelectedPath.Value.Select(section => section.Id).Should().Equal("admin", "roles");
+        shell.ChildLevels.Value[0].SelectedSection.Value.Id.Should().Be("roles");
+    }
+
+    [Fact]
+    public void Flat_sections_remain_supported()
+    {
+        using var provider = new ServiceCollection().BuildServiceProvider();
+        using var shell = new Shell([
+            CreateSection(provider, "settings", sortOrder: 1),
+            CreateSection(provider, "home", sortOrder: 0),
+        ], provider);
+
+        shell.RootLevel.Sections.Select(section => section.Id).Should().Equal("home", "settings");
+        shell.RootLevel.SelectedSection.Value.Id.Should().Be("home");
+        shell.SelectedSection.Value.Id.Should().Be("home");
+        shell.SelectedPath.Value.Select(section => section.Id).Should().Equal("home");
+        shell.ChildLevels.Value.Should().BeEmpty();
+    }
+
+    private static Section CreateSection(ServiceProvider provider, string id, string? parentId = null, int sortOrder = 0)
+    {
+        return new Section(id, provider, typeof(object), friendlyName: id, parentId: parentId)
+        {
+            SortOrder = sortOrder,
+        };
+    }
+}


### PR DESCRIPTION
Adds hierarchical shell section support to Zafiro.UI while keeping existing IShell and ISection contracts additive-compatible.\n\nKey points:\n- Adds IHierarchicalShell and IHierarchicalSection for hierarchy-specific UI and model access.\n- Keeps IShell and ISection as the stable base contracts.\n- Supports ParentId in SectionAttribute and section registration.\n- Adds tests for hierarchy selection, scoped navigation preservation, attribute registration, and AddSection compatibility.\n\nThis should be published before Zafiro.Avalonia consumes Zafiro.UI 47.0.10.